### PR TITLE
support gradle 6

### DIFF
--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.3-all.zip

--- a/src/main/java/edu/sc/seis/launch4j/Launch4jPlugin.java
+++ b/src/main/java/edu/sc/seis/launch4j/Launch4jPlugin.java
@@ -108,7 +108,7 @@ public class Launch4jPlugin implements Plugin<Project> {
         Jar jar = (Jar) project.getTasks().getByName(JavaPlugin.JAR_TASK_NAME);
 
         distSpec.from(jar);
-        distSpec.from(project.getConfigurations().getByName(UserConstants.CONFIG_RUNTIME));
+        distSpec.from(project.getConfigurations().getByName(UserConstants.CONFIG_RUNTIME_CLASSPATH));
 
         return distSpec;
     }

--- a/src/main/java/edu/sc/seis/launch4j/Launch4jPlugin.java
+++ b/src/main/java/edu/sc/seis/launch4j/Launch4jPlugin.java
@@ -1,6 +1,7 @@
 package edu.sc.seis.launch4j;
 
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.user.UserConstants;
 import org.gradle.api.*;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.plugins.JavaPlugin;
@@ -107,7 +108,7 @@ public class Launch4jPlugin implements Plugin<Project> {
         Jar jar = (Jar) project.getTasks().getByName(JavaPlugin.JAR_TASK_NAME);
 
         distSpec.from(jar);
-        distSpec.from(project.getConfigurations().getByName("runtime"));
+        distSpec.from(project.getConfigurations().getByName(UserConstants.CONFIG_RUNTIME));
 
         return distSpec;
     }

--- a/src/main/java/net/minecraftforge/gradle/ArchiveTaskHelper.java
+++ b/src/main/java/net/minecraftforge/gradle/ArchiveTaskHelper.java
@@ -11,7 +11,7 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 
 public class ArchiveTaskHelper {
-    private static AbstractArchiveTaskHelperBack back = GradleVersionUtils.choose(null, "5.1",
+    private static AbstractArchiveTaskHelperBack back = GradleVersionUtils.choose("5.1",
             new GradleVersionUtils.Callable<AbstractArchiveTaskHelperBack>() {
                 @Override
                 public AbstractArchiveTaskHelperBack call() {

--- a/src/main/java/net/minecraftforge/gradle/ArchiveTaskHelper.java
+++ b/src/main/java/net/minecraftforge/gradle/ArchiveTaskHelper.java
@@ -202,12 +202,12 @@ public class ArchiveTaskHelper {
 
         @Override
         public String getStringProperty(AbstractArchiveTask task, StringProperties prop) {
-            return ArchiveTaskHelper.<Property<String>>call(prop.forOldGetMethod, task).getOrNull();
+            return ArchiveTaskHelper.<Property<String>>call(prop.forNewMethod, task).getOrNull();
         }
 
         @Override
         public void setStringProperty(AbstractArchiveTask task, StringProperties prop, String value) {
-            ArchiveTaskHelper.<Property<String>>call(prop.forOldGetMethod, task).set(value);
+            ArchiveTaskHelper.<Property<String>>call(prop.forNewMethod, task).set(value);
         }
     }
 

--- a/src/main/java/net/minecraftforge/gradle/ArchiveTaskHelper.java
+++ b/src/main/java/net/minecraftforge/gradle/ArchiveTaskHelper.java
@@ -1,0 +1,223 @@
+package net.minecraftforge.gradle;
+
+import org.gradle.api.file.DirectoryProperty;
+import org.gradle.api.file.RegularFile;
+import org.gradle.api.provider.Property;
+import org.gradle.api.provider.Provider;
+import org.gradle.api.tasks.bundling.AbstractArchiveTask;
+
+import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class ArchiveTaskHelper {
+    private static AbstractArchiveTaskHelperBack back = GradleVersionUtils.choose(null, "5.1",
+            new GradleVersionUtils.Callable<AbstractArchiveTaskHelperBack>() {
+                @Override
+                public AbstractArchiveTaskHelperBack call() {
+                    return new AbstractArchiveTaskHelperBackImplOld();
+                }
+            },
+            new GradleVersionUtils.Callable<AbstractArchiveTaskHelperBack>() {
+                @Override
+                public AbstractArchiveTaskHelperBack call() {
+                    return new AbstractArchiveTaskHelperBackImplNew();
+                }
+            });
+
+    private ArchiveTaskHelper() {
+    }
+
+    public static File getArchivePath(AbstractArchiveTask task) {
+        return back.getArchivePath(task);
+    }
+
+    public static File getDestinationDir(AbstractArchiveTask task) {
+        return back.getDestinationDir(task);
+    }
+
+    public static void setDestinationDir(AbstractArchiveTask task, File destinationDir) {
+        back.setDestinationDir(task, destinationDir);
+    }
+
+    public static String getBaseName(AbstractArchiveTask task) {
+        return back.getStringProperty(task, StringProperties.BaseName);
+    }
+
+    public static void setBaseName(AbstractArchiveTask task, String value) {
+        back.setStringProperty(task, StringProperties.BaseName, value);
+    }
+
+    public static String getAppendix(AbstractArchiveTask task) {
+        return back.getStringProperty(task, StringProperties.Appendix);
+    }
+
+    public static void setAppendix(AbstractArchiveTask task, String value) {
+        back.setStringProperty(task, StringProperties.Appendix, value);
+    }
+
+    public static String getVersion(AbstractArchiveTask task) {
+        return back.getStringProperty(task, StringProperties.Version);
+    }
+
+    public static void setVersion(AbstractArchiveTask task, String value) {
+        back.setStringProperty(task, StringProperties.Version, value);
+    }
+
+    public static String getClassifier(AbstractArchiveTask task) {
+        return back.getStringProperty(task, StringProperties.Classifier);
+    }
+
+    public static void setClassifier(AbstractArchiveTask task, String value) {
+        back.setStringProperty(task, StringProperties.Classifier, value);
+    }
+
+    public static String getExtension(AbstractArchiveTask task) {
+        return back.getStringProperty(task, StringProperties.Extension);
+    }
+
+    public static void setExtension(AbstractArchiveTask task, String value) {
+        back.setStringProperty(task, StringProperties.Extension, value);
+    }
+
+    public static String getArchiveName(AbstractArchiveTask task) {
+        return back.getStringProperty(task, StringProperties.ArchiveName);
+    }
+
+    public static void setArchiveName(AbstractArchiveTask task, String value) {
+        back.setStringProperty(task, StringProperties.ArchiveName, value);
+    }
+
+    private enum StringProperties {
+        BaseName,
+        Appendix,
+        Version,
+        Classifier,
+        Extension,
+        ArchiveName("getArchiveFileName"),
+        ;
+        Method forOldGetMethod;
+        Method forOldSetMethod;
+        Method forNewMethod;
+
+        StringProperties() {
+            init("get" + name(), "set" + name(), "getArchive" + name());
+        }
+
+        StringProperties(String oldGetName, String oldSetName, String newName) {
+            init(oldGetName, oldSetName, newName);
+        }
+
+        StringProperties(String newName) {
+            init("get" + name(), "set" + name(), newName);
+        }
+
+        private void init(String oldGetName, String oldSetName, String newName) {
+            try {
+                forOldGetMethod = AbstractArchiveTask.class.getMethod(oldGetName);
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+            }
+            try {
+                forOldSetMethod = AbstractArchiveTask.class.getMethod(oldSetName, String.class);
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+            }
+            try {
+                forNewMethod = AbstractArchiveTask.class.getMethod(newName);
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+            }
+        }
+    }
+
+    private interface AbstractArchiveTaskHelperBack {
+        File getArchivePath(AbstractArchiveTask task);
+
+        File getDestinationDir(AbstractArchiveTask task);
+
+        void setDestinationDir(AbstractArchiveTask task, File destinationDir);
+
+        String getStringProperty(AbstractArchiveTask task, StringProperties prop);
+
+        void setStringProperty(AbstractArchiveTask task, StringProperties prop, String value);
+    }
+
+    private static class AbstractArchiveTaskHelperBackImplOld implements AbstractArchiveTaskHelperBack {
+        @Override
+        public File getArchivePath(AbstractArchiveTask task) {
+            return task.getArchivePath();
+        }
+
+        @Override
+        public File getDestinationDir(AbstractArchiveTask task) {
+            return task.getDestinationDir();
+        }
+
+        @Override
+        public void setDestinationDir(AbstractArchiveTask task, File destinationDir) {
+            task.setDestinationDir(destinationDir);
+        }
+
+        @Override
+        public String getStringProperty(AbstractArchiveTask task, StringProperties prop) {
+            return ArchiveTaskHelper.call(prop.forOldGetMethod, task);
+        }
+
+        @Override
+        public void setStringProperty(AbstractArchiveTask task, StringProperties prop, String value) {
+            ArchiveTaskHelper.call(prop.forOldSetMethod, task, value);
+        }
+    }
+
+    // @since 5.1
+    private static class AbstractArchiveTaskHelperBackImplNew implements AbstractArchiveTaskHelperBack {
+        static Method getArchiveFile;
+        static Method getDestinationDirectory;
+
+        static {
+            try {
+                getArchiveFile = AbstractArchiveTask.class.getMethod("getArchiveFile");
+                getDestinationDirectory = AbstractArchiveTask.class.getMethod("getDestinationDirectory");
+            } catch (NoSuchMethodException e) {
+                throw new RuntimeException(e);
+            }
+        }
+
+        @Override
+        public File getArchivePath(AbstractArchiveTask task) {
+            return ArchiveTaskHelper.<Provider<RegularFile>>call(getArchiveFile, task).get().getAsFile();
+        }
+
+        @Override
+        public File getDestinationDir(AbstractArchiveTask task) {
+            return ArchiveTaskHelper.<DirectoryProperty>call(getDestinationDirectory, task).getAsFile().get();
+        }
+
+        @Override
+        public void setDestinationDir(AbstractArchiveTask task, File destinationDir) {
+            ArchiveTaskHelper.<DirectoryProperty>call(getDestinationDirectory, task)
+                    .set(task.getProject().file(destinationDir));
+        }
+
+        @Override
+        public String getStringProperty(AbstractArchiveTask task, StringProperties prop) {
+            return ArchiveTaskHelper.<Property<String>>call(prop.forOldGetMethod, task).getOrNull();
+        }
+
+        @Override
+        public void setStringProperty(AbstractArchiveTask task, StringProperties prop, String value) {
+            ArchiveTaskHelper.<Property<String>>call(prop.forOldGetMethod, task).set(value);
+        }
+    }
+
+    private static <T> T call(Method method, Object self, Object... args) {
+        try {
+            return (T) method.invoke(self, args);
+        } catch (IllegalAccessException e) {
+            throw new RuntimeException(e);
+        } catch (InvocationTargetException e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/gradle/FileLogListenner.java
+++ b/src/main/java/net/minecraftforge/gradle/FileLogListenner.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.gradle;
 
 import com.google.common.io.Files;
+import org.gradle.BuildAdapter;
 import org.gradle.BuildListener;
 import org.gradle.BuildResult;
 import org.gradle.api.initialization.Settings;
@@ -13,7 +14,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.charset.Charset;
 
-public class FileLogListenner implements StandardOutputListener, BuildListener {
+public class FileLogListenner extends BuildAdapter implements StandardOutputListener, BuildListener {
     private final File out;
     private BufferedWriter writer;
 
@@ -37,14 +38,6 @@ public class FileLogListenner implements StandardOutputListener, BuildListener {
     }
 
     @Override
-    public void projectsLoaded(Gradle arg0) {
-    }
-
-    @Override
-    public void buildStarted(Gradle arg0) {
-    }
-
-    @Override
     public void onOutput(CharSequence arg0) {
         try {
             writer.write(arg0.toString());
@@ -61,13 +54,5 @@ public class FileLogListenner implements StandardOutputListener, BuildListener {
             e.printStackTrace();
         }
     }
-
-    @Override
-    public void projectsEvaluated(Gradle arg0) {
-    }  // nothing
-
-    @Override
-    public void settingsEvaluated(Settings arg0) {
-    } // nothing
 
 }

--- a/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
+++ b/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
@@ -1,0 +1,21 @@
+package net.minecraftforge.gradle;
+
+import org.gradle.api.Action;
+import org.gradle.api.Project;
+import org.gradle.util.VersionNumber;
+
+public class GradleVersionUtils {
+    /**
+     * @param project detect by version of gradle of this project
+     * @param versionName includes this version
+     * @param action the action runs if gradle version is equals to or after {@code versionName}.
+     */
+    public static void ifAfter(Project project, String versionName, Runnable action) {
+        VersionNumber gradleVersion = VersionNumber.parse(project.getGradle().getGradleVersion());
+        VersionNumber version = VersionNumber.parse(versionName);
+
+        if (gradleVersion.compareTo(version) > 0) {
+            action.run();
+        }
+    }
+}

--- a/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
+++ b/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
@@ -1,6 +1,5 @@
 package net.minecraftforge.gradle;
 
-import org.gradle.api.Action;
 import org.gradle.api.Project;
 import org.gradle.util.VersionNumber;
 
@@ -14,7 +13,21 @@ public class GradleVersionUtils {
         VersionNumber gradleVersion = VersionNumber.parse(project.getGradle().getGradleVersion());
         VersionNumber version = VersionNumber.parse(versionName);
 
-        if (gradleVersion.compareTo(version) > 0) {
+        if (gradleVersion.compareTo(version) >= 0) {
+            action.run();
+        }
+    }
+
+    /**
+     * @param project detect by version of gradle of this project
+     * @param versionName excludes this version
+     * @param action the action runs if gradle version is equals to or after {@code versionName}.
+     */
+    public static void ifBefore(Project project, String versionName, Runnable action) {
+        VersionNumber gradleVersion = VersionNumber.parse(project.getGradle().getGradleVersion());
+        VersionNumber version = VersionNumber.parse(versionName);
+
+        if (gradleVersion.compareTo(version) < 0) {
             action.run();
         }
     }

--- a/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
+++ b/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
@@ -1,17 +1,15 @@
 package net.minecraftforge.gradle;
 
-import org.gradle.api.Project;
-import org.gradle.util.VersionNumber;
+import org.gradle.util.GradleVersion;
 
 public class GradleVersionUtils {
     /**
-     * @param project detect by version of gradle of this project
      * @param versionName includes this version
      * @param action the action runs if gradle version is equals to or after {@code versionName}.
      */
-    public static void ifAfter(Project project, String versionName, Runnable action) {
-        VersionNumber gradleVersion = VersionNumber.parse(project.getGradle().getGradleVersion());
-        VersionNumber version = VersionNumber.parse(versionName);
+    public static void ifAfter(String versionName, Runnable action) {
+        GradleVersion gradleVersion = GradleVersion.current();
+        GradleVersion version = GradleVersion.version(versionName);
 
         if (gradleVersion.compareTo(version) >= 0) {
             action.run();
@@ -19,13 +17,12 @@ public class GradleVersionUtils {
     }
 
     /**
-     * @param project detect by version of gradle of this project
      * @param versionName excludes this version
      * @param action the action runs if gradle version is equals to or after {@code versionName}.
      */
-    public static void ifBefore(Project project, String versionName, Runnable action) {
-        VersionNumber gradleVersion = VersionNumber.parse(project.getGradle().getGradleVersion());
-        VersionNumber version = VersionNumber.parse(versionName);
+    public static void ifBefore(String versionName, Runnable action) {
+        GradleVersion gradleVersion = GradleVersion.current();
+        GradleVersion version = GradleVersion.version(versionName);
 
         if (gradleVersion.compareTo(version) < 0) {
             action.run();
@@ -33,12 +30,11 @@ public class GradleVersionUtils {
     }
     /**
      * same version includes after
-     * @param project detect by version of gradle of this project
      * @param versionName includes this version
      */
-    public static <T> T choose(Project project, String versionName, Callable<? extends T> before, Callable<? extends T> after) {
-        VersionNumber gradleVersion = VersionNumber.parse(project.getGradle().getGradleVersion());
-        VersionNumber version = VersionNumber.parse(versionName);
+    public static <T> T choose(String versionName, Callable<? extends T> before, Callable<? extends T> after) {
+        GradleVersion gradleVersion = GradleVersion.current();
+        GradleVersion version = GradleVersion.version(versionName);
 
         if (gradleVersion.compareTo(version) < 0) {
             return before.call();

--- a/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
+++ b/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
@@ -31,4 +31,23 @@ public class GradleVersionUtils {
             action.run();
         }
     }
+    /**
+     * same version includes after
+     * @param project detect by version of gradle of this project
+     * @param versionName includes this version
+     */
+    public static <T> T choose(Project project, String versionName, Callable<? extends T> before, Callable<? extends T> after) {
+        VersionNumber gradleVersion = VersionNumber.parse(project.getGradle().getGradleVersion());
+        VersionNumber version = VersionNumber.parse(versionName);
+
+        if (gradleVersion.compareTo(version) < 0) {
+            return before.call();
+        } else {
+            return after.call();
+        }
+    }
+
+    public interface Callable<T> {
+        T call();
+    }
 }

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -392,7 +392,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
                 repo.setName(name);
                 repo.setUrl(url);
                 if (!usePom) {
-                    GradleVersionUtils.ifAfter(proj, "4.5", new Runnable() {
+                    GradleVersionUtils.ifAfter("4.5", new Runnable() {
                         @Override
                         public void run() {
                             repo.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -12,6 +12,7 @@ import com.google.gson.reflect.TypeToken;
 import groovy.lang.Closure;
 import net.minecraftforge.gradle.FileLogListenner;
 import net.minecraftforge.gradle.GradleConfigurationException;
+import net.minecraftforge.gradle.GradleVersionUtils;
 import net.minecraftforge.gradle.delayed.DelayedBase.IDelayedResolver;
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import net.minecraftforge.gradle.delayed.DelayedFileTree;
@@ -384,17 +385,22 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
         return addMavenRepo(proj, name, url, true);
     }
 
-    public MavenArtifactRepository addMavenRepo(Project proj, final String name, final String url, final boolean usePom) {
+    public MavenArtifactRepository addMavenRepo(final Project proj, final String name, final String url, final boolean usePom) {
         return proj.getRepositories().maven(new Action<MavenArtifactRepository>() {
             @Override
-            public void execute(MavenArtifactRepository repo) {
+            public void execute(final MavenArtifactRepository repo) {
                 repo.setName(name);
                 repo.setUrl(url);
                 if (!usePom) {
-                    repo.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {
+                    GradleVersionUtils.ifAfter(proj, "4.5", new Runnable() {
                         @Override
-                        public void execute(MavenArtifactRepository.MetadataSources metadataSources) {
-                            metadataSources.artifact();
+                        public void run() {
+                            repo.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {
+                                @Override
+                                public void execute(MavenArtifactRepository.MetadataSources metadataSources) {
+                                    metadataSources.artifact();
+                                }
+                            });
                         }
                     });
                 }

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -93,7 +93,8 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
         // repos
         project.allprojects(new Action<Project>() {
             public void execute(Project proj) {
-                addMavenRepo(proj, "forge", Constants.FORGE_MAVEN);
+                // the forge's repository doesn't have pom file.
+                addMavenRepo(proj, "forge", Constants.FORGE_MAVEN, false);
                 proj.getRepositories().mavenCentral();
                 addMavenRepo(proj, "minecraft", Constants.LIBRARY_URL);
             }
@@ -380,11 +381,23 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
     }
 
     public MavenArtifactRepository addMavenRepo(Project proj, final String name, final String url) {
+        return addMavenRepo(proj, name, url, true);
+    }
+
+    public MavenArtifactRepository addMavenRepo(Project proj, final String name, final String url, final boolean usePom) {
         return proj.getRepositories().maven(new Action<MavenArtifactRepository>() {
             @Override
             public void execute(MavenArtifactRepository repo) {
                 repo.setName(name);
                 repo.setUrl(url);
+                if (!usePom) {
+                    repo.metadataSources(new Action<MavenArtifactRepository.MetadataSources>() {
+                        @Override
+                        public void execute(MavenArtifactRepository.MetadataSources metadataSources) {
+                            metadataSources.artifact();
+                        }
+                    });
+                }
             }
         });
     }

--- a/src/main/java/net/minecraftforge/gradle/curseforge/CursePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/curseforge/CursePlugin.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.gradle.curseforge;
 
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.user.UserBasePlugin;
 import net.minecraftforge.gradle.user.UserExtension;
 import org.gradle.api.Action;
@@ -22,7 +23,7 @@ public class CursePlugin implements Plugin<Project> {
         upload.setArtifact(new Closure(null, null) {
             public Object call() {
                 if (project.getPlugins().hasPlugin("java"))
-                    return ((Jar) project.getTasks().getByName("jar")).getArchivePath();
+                    return ArchiveTaskHelper.getArchivePath((Jar) project.getTasks().getByName("jar"));
                 return null;
             }
 

--- a/src/main/java/net/minecraftforge/gradle/curseforge/CurseUploadTask.java
+++ b/src/main/java/net/minecraftforge/gradle/curseforge/CurseUploadTask.java
@@ -8,6 +8,7 @@ import gnu.trove.TIntArrayList;
 import gnu.trove.TIntHashSet;
 import gnu.trove.TObjectIntHashMap;
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.StringUtils;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
@@ -380,7 +381,7 @@ public class CurseUploadTask extends DefaultTask {
         if (object instanceof File) {
             return (File) object;
         } else if (object instanceof AbstractArchiveTask) {
-            return ((AbstractArchiveTask) object).getArchivePath();
+            return ArchiveTaskHelper.getArchivePath((AbstractArchiveTask) object);
         } else if (object instanceof DelayedFile) {
             return ((DelayedFile) object).call();
         } else {

--- a/src/main/java/net/minecraftforge/gradle/delayed/DelayedFileTree.java
+++ b/src/main/java/net/minecraftforge/gradle/delayed/DelayedFileTree.java
@@ -1,6 +1,5 @@
 package net.minecraftforge.gradle.delayed;
 
-import net.minecraftforge.gradle.ZipFileTree;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileTree;
 import org.gradle.api.internal.file.collections.FileTreeAdapter;
@@ -32,8 +31,7 @@ public class DelayedFileTree extends DelayedBase<FileTree> {
     @Override
     public FileTree resolveDelayed() {
         if (zipTree)
-            //resolved = project.zipTree(DelayedString.resolve(pattern, project, resolvers));
-            return new FileTreeAdapter(new ZipFileTree(project.file(DelayedBase.resolve(pattern, project, resolvers))));
+            return project.zipTree(DelayedString.resolve(pattern, project, resolvers));
         else
             return project.fileTree(DelayedBase.resolve(pattern, project, resolvers));
     }

--- a/src/main/java/net/minecraftforge/gradle/delayed/DelayedThingy.java
+++ b/src/main/java/net/minecraftforge/gradle/delayed/DelayedThingy.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.gradle.delayed;
 
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 
@@ -15,7 +16,7 @@ public class DelayedThingy extends Closure<Object> {
 
     public Object call(Object... objects) {
         if (thing instanceof AbstractArchiveTask)
-            return ((AbstractArchiveTask) thing).getArchivePath();
+            return ArchiveTaskHelper.getArchivePath((AbstractArchiveTask) thing);
         else if ((thing instanceof PublishArtifact))
             return ((PublishArtifact) thing).getFile();
 

--- a/src/main/java/net/minecraftforge/gradle/dev/CauldronDevPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/CauldronDevPlugin.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.gradle.dev;
 
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.CopyInto;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
@@ -453,7 +454,7 @@ public class CauldronDevPlugin extends DevBasePlugin {
 
         final DelayedJar uni = makeTask("packageUniversal", DelayedJar.class);
         {
-            uni.setClassifier(delayedString("B{BUILD_NUM}").call());
+            ArchiveTaskHelper.setClassifier(uni, delayedString("B{BUILD_NUM}").call());
             uni.getInputs().file(delayedFile(EXTRA_JSON_REL));
             uni.getOutputs().upToDateWhen(Constants.CALL_FALSE);
             uni.from(delayedZipTree(BINPATCH_TMP));
@@ -500,7 +501,7 @@ public class CauldronDevPlugin extends DevBasePlugin {
 //                }
 //            });
 
-            uni.setDestinationDir(delayedFile("{BUILD_DIR}/distributions").call());
+            ArchiveTaskHelper.setDestinationDir(uni, delayedFile("{BUILD_DIR}/distributions").call());
             //uni.dependsOn("genBinPatches", "createChangelog", "createVersionPropertiesFML", "generateVersionJson");
             uni.dependsOn("genBinPatches", "createChangelog", "createVersionPropertiesFML");
         }
@@ -516,7 +517,7 @@ public class CauldronDevPlugin extends DevBasePlugin {
             task.addReplacement("@artifact@", delayedString("net.minecraftforge:forge:{MC_VERSION}-{VERSION}"));
             task.addReplacement("@universal_jar@", new Closure<String>(project) {
                 public String call() {
-                    return uni.getArchiveName();
+                    return ArchiveTaskHelper.getArchiveName(uni);
                 }
             });
             task.addReplacement("@timestamp@", new Closure<String>(project) {
@@ -528,10 +529,10 @@ public class CauldronDevPlugin extends DevBasePlugin {
 
         Zip inst = makeTask("packageInstaller", Zip.class);
         {
-            inst.setClassifier("installer");
+            ArchiveTaskHelper.setClassifier(inst, "installer");
             inst.from(new Closure<File>(project) {
                 public File call() {
-                    return uni.getArchivePath();
+                    return ArchiveTaskHelper.getArchivePath(uni);
                 }
             });
             inst.from(delayedFile(INSTALL_PROFILE));
@@ -546,7 +547,7 @@ public class CauldronDevPlugin extends DevBasePlugin {
             inst.from(delayedZipTree(INSTALLER_BASE), new CopyInto("", "!*.json", "!*.png"));
             inst.dependsOn("packageUniversal", "downloadBaseInstaller", "generateInstallJson");
             inst.rename("forge_logo\\.png", "big_logo.png");
-            inst.setExtension("jar");
+            ArchiveTaskHelper.setExtension(inst, "jar");
         }
         project.getArtifacts().add("archives", inst);
     }

--- a/src/main/java/net/minecraftforge/gradle/dev/CauldronDevPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/CauldronDevPlugin.java
@@ -311,7 +311,7 @@ public class CauldronDevPlugin extends DevBasePlugin {
 
         ExtractS2SRangeTask extractRange = makeTask("extractRangeCauldron", ExtractS2SRangeTask.class);
         {
-            extractRange.setLibsFromProject(delayedFile(ECLIPSE_CDN + "/build.gradle"), "compile", true);
+            extractRange.setLibsFromProject(delayedFile(ECLIPSE_CDN + "/build.gradle"), CONFIG_COMPILE, true);
             extractRange.addIn(delayedFile(ECLIPSE_CDN_SRC));
             extractRange.setRangeMap(rangeMapDirty);
         }
@@ -338,7 +338,7 @@ public class CauldronDevPlugin extends DevBasePlugin {
 
         extractRange = makeTask("extractRangeClean", ExtractS2SRangeTask.class);
         {
-            extractRange.setLibsFromProject(delayedFile(ECLIPSE_CLEAN + "/build.gradle"), "compile", true);
+            extractRange.setLibsFromProject(delayedFile(ECLIPSE_CLEAN + "/build.gradle"), CONFIG_COMPILE, true);
             extractRange.addIn(delayedFile(REMAPPED_CLEAN));
             extractRange.setRangeMap(rangeMapClean);
         }

--- a/src/main/java/net/minecraftforge/gradle/dev/DevBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/DevBasePlugin.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonParser;
 import edu.sc.seis.launch4j.Launch4jPluginExtension;
 import groovy.lang.Closure;
 import groovy.util.MapEntry;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.common.BasePlugin;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
@@ -178,7 +179,7 @@ public abstract class DevBasePlugin extends BasePlugin<DevExtension> {
         if (!hasInstaller())
             return;
 
-        final File installer = ((Zip) project.getTasks().getByName("packageInstaller")).getArchivePath();
+        final File installer = ArchiveTaskHelper.getArchivePath((Zip) project.getTasks().getByName("packageInstaller"));
 
         File output = new File(installer.getParentFile(), installer.getName().replace(".jar", "-win.exe"));
         project.getArtifacts().add("archives", output);

--- a/src/main/java/net/minecraftforge/gradle/dev/DevConstants.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/DevConstants.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.gradle.dev;
 
 import net.minecraftforge.gradle.common.Constants;
+import net.minecraftforge.gradle.user.UserConstants;
 
 final class DevConstants {
     private DevConstants() {
@@ -156,6 +157,7 @@ final class DevConstants {
     static final String CROWDIN_FORGEID = "minecraft-forge";
 
     // build configurations. same as in UserConstants
-    public static final String CONFIG_RUNTIME = "runtimeOnly";
-    public static final String CONFIG_COMPILE = "implementation";
+    public static final String CONFIG_RUNTIME = UserConstants.CONFIG_RUNTIME;
+    public static final String CONFIG_RUNTIME_CLASSPATH = UserConstants.CONFIG_RUNTIME_CLASSPATH;
+    public static final String CONFIG_COMPILE = UserConstants.CONFIG_COMPILE;
 }

--- a/src/main/java/net/minecraftforge/gradle/dev/DevConstants.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/DevConstants.java
@@ -154,4 +154,8 @@ final class DevConstants {
     // CrowdIn Stuff
     static final String CROWDIN_ZIP = "{BUILD_DIR}/crowdin-localizations.zip";
     static final String CROWDIN_FORGEID = "minecraft-forge";
+
+    // build configurations. same as in UserConstants
+    public static final String CONFIG_RUNTIME = "runtimeOnly";
+    public static final String CONFIG_COMPILE = "implementation";
 }

--- a/src/main/java/net/minecraftforge/gradle/dev/DevExtension.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/DevExtension.java
@@ -4,7 +4,7 @@ import groovy.lang.Closure;
 import net.minecraftforge.gradle.common.BaseExtension;
 import org.gradle.api.Action;
 import org.gradle.api.Project;
-import org.gradle.api.internal.ClosureBackedAction;
+import org.gradle.util.ConfigureUtil;
 
 public class DevExtension extends BaseExtension {
     private String fmlDir;
@@ -80,7 +80,7 @@ public class DevExtension extends BaseExtension {
 
     @SuppressWarnings("rawtypes")
     public void subprojects(Closure subprojects) {
-        this.subprojects = new ClosureBackedAction<Project>(subprojects);
+        this.subprojects = ConfigureUtil.configureUsing(subprojects);
     }
 
     public Action<Project> getCleanProject() {
@@ -93,7 +93,7 @@ public class DevExtension extends BaseExtension {
 
     @SuppressWarnings("rawtypes")
     public void cleanProject(Closure subprojects) {
-        this.cleanProject = new ClosureBackedAction<Project>(subprojects);
+        this.cleanProject = ConfigureUtil.configureUsing(subprojects);
     }
 
     public Action<Project> getDirtyProject() {
@@ -106,7 +106,7 @@ public class DevExtension extends BaseExtension {
 
     @SuppressWarnings("rawtypes")
     public void dirtyProject(Closure subprojects) {
-        this.dirtyProject = new ClosureBackedAction<Project>(subprojects);
+        this.dirtyProject = ConfigureUtil.configureUsing(subprojects);
     }
 
     public boolean getMakeJavadoc() {

--- a/src/main/java/net/minecraftforge/gradle/dev/EduDevPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/EduDevPlugin.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.gradle.dev;
 
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import net.minecraftforge.gradle.tasks.*;
@@ -419,7 +420,7 @@ public class EduDevPlugin extends DevBasePlugin {
 
         final DelayedJar uni = makeTask("packageUniversal", DelayedJar.class);
         {
-            uni.setClassifier(delayedString("B{BUILD_NUM}").call());
+            ArchiveTaskHelper.setClassifier(uni, delayedString("B{BUILD_NUM}").call());
             uni.getInputs().file(delayedFile(EXTRA_JSON_REL));
             uni.getOutputs().upToDateWhen(Constants.CALL_FALSE);
             uni.from(delayedZipTree(BINPATCH_TMP));
@@ -466,7 +467,7 @@ public class EduDevPlugin extends DevBasePlugin {
 //                }
 //            });
 
-            uni.setDestinationDir(delayedFile("{BUILD_DIR}/distributions").call());
+            ArchiveTaskHelper.setDestinationDir(uni, delayedFile("{BUILD_DIR}/distributions").call());
             //uni.dependsOn("genBinPatches", "createChangelog", "createVersionPropertiesFML", "generateVersionJson");
             uni.dependsOn("genBinPatches", "createVersionPropertiesFML");
         }

--- a/src/main/java/net/minecraftforge/gradle/dev/EduDevPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/EduDevPlugin.java
@@ -292,7 +292,7 @@ public class EduDevPlugin extends DevBasePlugin {
 
         ExtractS2SRangeTask extractRange = makeTask("extractRangeMcEdu", ExtractS2SRangeTask.class);
         {
-            extractRange.setLibsFromProject(delayedFile(ECLIPSE_EDU + "/build.gradle"), "compile", true);
+            extractRange.setLibsFromProject(delayedFile(ECLIPSE_EDU + "/build.gradle"), CONFIG_COMPILE, true);
             extractRange.addIn(delayedFile(ECLIPSE_EDU_SRC));
             extractRange.setRangeMap(rangeMapDirty);
         }
@@ -319,7 +319,7 @@ public class EduDevPlugin extends DevBasePlugin {
 
         extractRange = makeTask("extractRangeClean", ExtractS2SRangeTask.class);
         {
-            extractRange.setLibsFromProject(delayedFile(ECLIPSE_CLEAN + "/build.gradle"), "compile", true);
+            extractRange.setLibsFromProject(delayedFile(ECLIPSE_CLEAN + "/build.gradle"), CONFIG_COMPILE, true);
             extractRange.addIn(delayedFile(REMAPPED_CLEAN));
             extractRange.setRangeMap(rangeMapClean);
         }

--- a/src/main/java/net/minecraftforge/gradle/dev/FmlDevPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/FmlDevPlugin.java
@@ -3,6 +3,7 @@ package net.minecraftforge.gradle.dev;
 //import edu.sc.seis.launch4j.Launch4jPluginExtension;
 
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.CopyInto;
 import net.minecraftforge.gradle.common.BasePlugin;
 import net.minecraftforge.gradle.common.Constants;
@@ -351,7 +352,7 @@ public class FmlDevPlugin extends DevBasePlugin {
 
         final DelayedJar uni = makeTask("packageUniversal", DelayedJar.class);
         {
-            uni.setClassifier("universal");
+            ArchiveTaskHelper.setClassifier(uni, "universal");
             uni.getInputs().file(delayedFile(DevConstants.JSON_REL));
             uni.getOutputs().upToDateWhen(Constants.CALL_FALSE);
             uni.from(delayedZipTree(DevConstants.BINPATCH_TMP));
@@ -388,7 +389,7 @@ public class FmlDevPlugin extends DevBasePlugin {
             genInstallJson.addReplacement("@artifact@", delayedString("cpw.mods:fml:{MC_VERSION_SAFE}-{VERSION}"));
             genInstallJson.addReplacement("@universal_jar@", new Closure<String>(project) {
                 public String call() {
-                    return uni.getArchiveName();
+                    return ArchiveTaskHelper.getArchiveName(uni);
                 }
             });
             genInstallJson.addReplacement("@timestamp@", new Closure<String>(project) {
@@ -400,10 +401,10 @@ public class FmlDevPlugin extends DevBasePlugin {
 
         Zip inst = makeTask("packageInstaller", Zip.class);
         {
-            inst.setClassifier("installer");
+            ArchiveTaskHelper.setClassifier(inst,"installer");
             inst.from(new Closure<File>(project) {
                 public File call() {
-                    return uni.getArchivePath();
+                    return ArchiveTaskHelper.getArchivePath(uni);
                 }
             });
             inst.from(delayedFile(DevConstants.INSTALL_PROFILE));
@@ -413,20 +414,20 @@ public class FmlDevPlugin extends DevBasePlugin {
             inst.from(delayedFile(DevConstants.FML_LOGO));
             inst.from(delayedZipTree(DevConstants.INSTALLER_BASE), new CopyInto("/", "!*.json", "!*.png"));
             inst.dependsOn(uni, "downloadBaseInstaller", genInstallJson);
-            inst.setExtension("jar");
+            ArchiveTaskHelper.setExtension(inst,"jar");
         }
         project.getArtifacts().add("archives", inst);
 
         final Zip patchZip = makeTask("zipPatches", Zip.class);
         {
             patchZip.from(delayedFile(DevConstants.FML_PATCH_DIR));
-            patchZip.setArchiveName("fmlpatches.zip");
+            ArchiveTaskHelper.setArchiveName(patchZip, "fmlpatches.zip");
         }
 
         final Zip classZip = makeTask("jarClasses", Zip.class);
         {
             classZip.from(delayedZipTree(DevConstants.BINPATCH_TMP), new CopyInto("", "**/*.class"));
-            classZip.setArchiveName("binaries.jar");
+            ArchiveTaskHelper.setArchiveName(classZip, "binaries.jar");
         }
 
         ExtractS2SRangeTask range = makeTask("userDevExtractRange", ExtractS2SRangeTask.class);
@@ -458,16 +459,16 @@ public class FmlDevPlugin extends DevBasePlugin {
 
         Zip userDev = makeTask("packageUserDev", Zip.class);
         {
-            userDev.setClassifier("userdev");
+            ArchiveTaskHelper.setClassifier(userDev,"userdev");
             userDev.from(delayedFile(DevConstants.JSON_DEV));
             userDev.from(new Closure<File>(project) {
                 public File call() {
-                    return patchZip.getArchivePath();
+                    return ArchiveTaskHelper.getArchivePath(patchZip);
                 }
             });
             userDev.from(new Closure<File>(project) {
                 public File call() {
-                    return classZip.getArchivePath();
+                    return ArchiveTaskHelper.getArchivePath(classZip);
                 }
             });
             userDev.from(delayedFile(DevConstants.CHANGELOG));
@@ -488,13 +489,13 @@ public class FmlDevPlugin extends DevBasePlugin {
             userDev.setIncludeEmptyDirs(false);
             uni.setDuplicatesStrategy(DuplicatesStrategy.EXCLUDE);
             userDev.dependsOn("packageUniversal", crowdin, patchZip, classZip, "createVersionProperties", s2s);
-            userDev.setExtension("jar");
+            ArchiveTaskHelper.setExtension(userDev,"jar");
         }
         project.getArtifacts().add("archives", userDev);
 
         Zip src = makeTask("packageSrc", Zip.class);
         {
-            src.setClassifier("src");
+            ArchiveTaskHelper.setClassifier(src, "src");
             src.from(delayedFile(DevConstants.CHANGELOG));
             src.from(delayedFile(DevConstants.FML_LICENSE));
             src.from(delayedFile(DevConstants.FML_CREDITS));
@@ -508,7 +509,7 @@ public class FmlDevPlugin extends DevBasePlugin {
             src.from(delayedFile("{FML_DIR}/gradle/wrapper"), new CopyInto("gradle/wrapper"));
             src.rename(".+?\\.gradle", "build.gradle");
             src.dependsOn("createChangelog");
-            src.setExtension("zip");
+            ArchiveTaskHelper.setExtension(src,"zip");
         }
         project.getArtifacts().add("archives", src);
     }

--- a/src/main/java/net/minecraftforge/gradle/dev/FmlDevPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/FmlDevPlugin.java
@@ -252,7 +252,7 @@ public class FmlDevPlugin extends DevBasePlugin {
 
         ExtractS2SRangeTask task = makeTask("extractRange", ExtractS2SRangeTask.class);
         {
-            task.setLibsFromProject(delayedFile(DevConstants.ECLIPSE_FML + "/build.gradle"), "compile", true);
+            task.setLibsFromProject(delayedFile(DevConstants.ECLIPSE_FML + "/build.gradle"), CONFIG_COMPILE, true);
             task.addIn(delayedFile(DevConstants.ECLIPSE_FML_SRC));
             //task.addIn(delayedFile(DevConstants.FML_SOURCES));
             task.setExcOutput(delayedFile(DevConstants.EXC_MODIFIERS_DIRTY));
@@ -431,7 +431,7 @@ public class FmlDevPlugin extends DevBasePlugin {
 
         ExtractS2SRangeTask range = makeTask("userDevExtractRange", ExtractS2SRangeTask.class);
         {
-            range.setLibsFromProject(delayedFile(DevConstants.ECLIPSE_FML + "/build.gradle"), "compile", true);
+            range.setLibsFromProject(delayedFile(DevConstants.ECLIPSE_FML + "/build.gradle"), CONFIG_COMPILE, true);
             range.addIn(delayedFile(DevConstants.FML_SOURCES));
             range.setRangeMap(delayedFile(DevConstants.USERDEV_RANGEMAP));
             range.dependsOn("generateProjects", "extractFmlSources");

--- a/src/main/java/net/minecraftforge/gradle/dev/ForgeDevPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/dev/ForgeDevPlugin.java
@@ -281,7 +281,7 @@ public class ForgeDevPlugin extends DevBasePlugin {
 
         ExtractS2SRangeTask extractRange = makeTask("extractRangeForge", ExtractS2SRangeTask.class);
         {
-            extractRange.setLibsFromProject(delayedFile(ECLIPSE_FORGE + "/build.gradle"), "compile", true);
+            extractRange.setLibsFromProject(delayedFile(ECLIPSE_FORGE + "/build.gradle"), CONFIG_COMPILE, true);
             extractRange.addIn(delayedFile(ECLIPSE_FORGE_SRC));
             extractRange.setExcOutput(delayedFile(EXC_MODIFIERS_DIRTY));
             extractRange.setRangeMap(rangeMapDirty);
@@ -311,7 +311,7 @@ public class ForgeDevPlugin extends DevBasePlugin {
 
         extractRange = makeTask("extractRangeClean", ExtractS2SRangeTask.class);
         {
-            extractRange.setLibsFromProject(delayedFile(ECLIPSE_CLEAN + "/build.gradle"), "compile", true);
+            extractRange.setLibsFromProject(delayedFile(ECLIPSE_CLEAN + "/build.gradle"), CONFIG_COMPILE, true);
             extractRange.addIn(delayedFile(REMAPPED_CLEAN));
             extractRange.setExcOutput(delayedFile(EXC_MODIFIERS_CLEAN));
             extractRange.setRangeMap(rangeMapClean);
@@ -541,7 +541,7 @@ public class ForgeDevPlugin extends DevBasePlugin {
 
         ExtractS2SRangeTask range = makeTask("userDevExtractRange", ExtractS2SRangeTask.class);
         {
-            range.setLibsFromProject(delayedFile(DevConstants.ECLIPSE_FORGE + "/build.gradle"), "compile", true);
+            range.setLibsFromProject(delayedFile(DevConstants.ECLIPSE_FORGE + "/build.gradle"), CONFIG_COMPILE, true);
             range.addIn(delayedFile(DevConstants.FML_SOURCES));
             range.addIn(delayedFile(DevConstants.FORGE_SOURCES));
             range.setRangeMap(delayedFile(DevConstants.USERDEV_RANGEMAP));

--- a/src/main/java/net/minecraftforge/gradle/tasks/ExtractS2SRangeTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ExtractS2SRangeTask.java
@@ -19,7 +19,6 @@ import net.minecraftforge.srg2source.util.io.ZipInputSupplier;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.tasks.InputFiles;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.OutputFile;
@@ -260,7 +259,7 @@ public class ExtractS2SRangeTask extends DefaultTask {
             libs = proj.getConfigurations().getByName(projectConfig);
 
             if (includeJar) {
-                AbstractTask jarTask = (AbstractTask) proj.getTasks().getByName("jar");
+                DefaultTask jarTask = (DefaultTask) proj.getTasks().getByName("jar");
                 executeTask(jarTask);
                 File compiled = (File) jarTask.property("archivePath");
                 libs = getProject().files(compiled, libs);
@@ -274,9 +273,9 @@ public class ExtractS2SRangeTask extends DefaultTask {
         return libs;
     }
 
-    private void executeTask(AbstractTask task) {
+    private void executeTask(DefaultTask task) {
         for (Object dep : task.getTaskDependencies().getDependencies(task)) {
-            executeTask((AbstractTask) dep);
+            executeTask((DefaultTask) dep);
         }
 
         if (!task.getState().getExecuted()) {

--- a/src/main/java/net/minecraftforge/gradle/tasks/dev/ObfuscateTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/dev/ObfuscateTask.java
@@ -14,7 +14,6 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.file.FileCollection;
-import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.*;
@@ -47,8 +46,8 @@ public class ObfuscateTask extends DefaultTask {
                 act.execute(childProj);
         }
 
-        AbstractTask compileTask = (AbstractTask) childProj.getTasks().getByName("compileJava");
-        AbstractTask jarTask = (AbstractTask) childProj.getTasks().getByName(subTask);
+        DefaultTask compileTask = (DefaultTask) childProj.getTasks().getByName("compileJava");
+        DefaultTask jarTask = (DefaultTask) childProj.getTasks().getByName(subTask);
 
         // executing jar task
         getLogger().debug("Executing child " + subTask + " task...");
@@ -87,9 +86,9 @@ public class ObfuscateTask extends DefaultTask {
         obfuscate(inJar, (FileCollection) compileTask.property("classpath"), srg);
     }
 
-    private void executeTask(AbstractTask task) {
+    private void executeTask(DefaultTask task) {
         for (Object dep : task.getTaskDependencies().getDependencies(task)) {
-            executeTask((AbstractTask) dep);
+            executeTask((DefaultTask) dep);
         }
 
         if (!task.getState().getExecuted()) {

--- a/src/main/java/net/minecraftforge/gradle/tasks/dev/SubprojectTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/dev/SubprojectTask.java
@@ -6,7 +6,6 @@ import org.gradle.api.Action;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.Project;
 import org.gradle.api.Task;
-import org.gradle.api.internal.AbstractTask;
 import org.gradle.api.tasks.TaskAction;
 
 import java.io.File;
@@ -35,16 +34,16 @@ public class SubprojectTask extends DefaultTask {
             for (Task t : list) {
                 if (configureTask != null)
                     configureTask.execute(t);
-                executeTask((AbstractTask) t);
+                executeTask((DefaultTask) t);
             }
         }
 
         System.gc();
     }
 
-    private void executeTask(AbstractTask task) {
+    private void executeTask(DefaultTask task) {
         for (Object dep : task.getTaskDependencies().getDependencies(task)) {
-            executeTask((AbstractTask) dep);
+            executeTask((DefaultTask) dep);
         }
 
         if (!task.getState().getExecuted()) {

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ArtifactSpec.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ArtifactSpec.java
@@ -3,6 +3,7 @@ package net.minecraftforge.gradle.tasks.user.reobf;
 import com.google.common.base.Strings;
 import com.google.common.io.Files;
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import net.minecraftforge.gradle.user.UserConstants;
@@ -56,32 +57,32 @@ public class ArtifactSpec {
         project = task.getProject();
         baseName = new Closure(null) {
             public Object call() {
-                return task.getBaseName();
+                return ArchiveTaskHelper.getBaseName(task);
             }
         };
         appendix = new Closure(null) {
             public Object call() {
-                return task.getAppendix();
+                return ArchiveTaskHelper.getAppendix(task);
             }
         };
         version = new Closure(null) {
             public Object call() {
-                return task.getVersion();
+                return ArchiveTaskHelper.getVersion(task);
             }
         };
         classifier = new Closure(null) {
             public Object call() {
-                return task.getClassifier();
+                return ArchiveTaskHelper.getClassifier(task);
             }
         };
         extension = new Closure(null) {
             public Object call() {
-                return task.getExtension();
+                return ArchiveTaskHelper.getExtension(task);
             }
         };
         archiveName = new Closure(null) {
             public Object call() {
-                return task.getArchiveName();
+                return ArchiveTaskHelper.getArchiveName(task);
             }
         };
         classpath = new Closure(null) {

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class ReobfTask extends DefaultTask {
-    final private DomainObjectSet<ObfArtifact> obfOutput = GradleVersionUtils.choose(getProject(), "5.5",
+    final private DomainObjectSet<ObfArtifact> obfOutput = GradleVersionUtils.choose("5.5",
             new GradleVersionUtils.Callable<DefaultDomainObjectSet<ObfArtifact>>() {
                 @Override
                 public DefaultDomainObjectSet<ObfArtifact> call() {

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
@@ -4,6 +4,7 @@ import com.google.common.base.Charsets;
 import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.GradleVersionUtils;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import net.minecraftforge.gradle.delayed.DelayedString;
@@ -16,17 +17,53 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.DefaultDomainObjectSet;
+import org.gradle.api.model.ObjectFactory;
 import org.gradle.api.tasks.*;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 
+import javax.inject.Inject;
 import java.io.BufferedWriter;
 import java.io.File;
 import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 
 public class ReobfTask extends DefaultTask {
-    final private DefaultDomainObjectSet<ObfArtifact> obfOutput = new DefaultDomainObjectSet<ObfArtifact>(ObfArtifact.class);
+    final private DomainObjectSet<ObfArtifact> obfOutput = GradleVersionUtils.choose(getProject(), "5.5",
+            new GradleVersionUtils.Callable<DefaultDomainObjectSet<ObfArtifact>>() {
+                @Override
+                public DefaultDomainObjectSet<ObfArtifact> call() {
+                    return new DefaultDomainObjectSet<ObfArtifact>(ObfArtifact.class);
+                }
+            }, new GradleVersionUtils.Callable<DomainObjectSet<ObfArtifact>>() {
+                @Override
+                public DomainObjectSet<ObfArtifact> call() {
+                    return ObfOutputCreateHelper.domainObjectSet(getInjectedObjectFactory(), ObfArtifact.class);
+                }
+            });
+    private static class ObfOutputCreateHelper {
+        static Method method;
+
+        static {
+            try {
+                method = ObjectFactory.class.getMethod("domainObjectSet", Class.class);
+            } catch (NoSuchMethodException e) {
+                e.printStackTrace();
+            }
+        }
+
+        public static <T> DomainObjectSet<T> domainObjectSet(ObjectFactory factory, Class<T> elementType) {
+            try {
+                return (DomainObjectSet<T>) method.invoke(factory, elementType);
+            } catch (IllegalAccessException e) {
+                throw new RuntimeException(e);
+            } catch (InvocationTargetException e) {
+                throw new RuntimeException(e);
+            }
+        }
+    }
 
     @Input
     private boolean useRetroGuard = false;
@@ -77,6 +114,11 @@ public class ReobfTask extends DefaultTask {
                 return getObfuscatedFiles();
             }
         });
+    }
+
+    @Inject
+    protected ObjectFactory getInjectedObjectFactory() {
+        throw new IllegalStateException("must be injected");
     }
 
     public void reobf(Task task, Action<ArtifactSpec> artifactSpec) {
@@ -459,7 +501,7 @@ public class ReobfTask extends DefaultTask {
         this.methodCsv = methodCsv;
     }
 
-    public DefaultDomainObjectSet<ObfArtifact> getObfOutput() {
+    public DomainObjectSet<ObfArtifact> getObfOutput() {
         return obfOutput;
     }
 

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -1087,28 +1087,28 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
 
         JavaExec exec = (JavaExec) project.getTasks().getByName("runClient");
         {
-            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
+            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME_CLASSPATH));
             exec.classpath(ArchiveTaskHelper.getArchivePath(jarTask));
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("runServer");
         {
-            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
+            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME_CLASSPATH));
             exec.classpath(ArchiveTaskHelper.getArchivePath(jarTask));
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("debugClient");
         {
-            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
+            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME_CLASSPATH));
             exec.classpath(ArchiveTaskHelper.getArchivePath(jarTask));
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("debugServer");
         {
-            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
+            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME_CLASSPATH));
             exec.classpath(ArchiveTaskHelper.getArchivePath(jarTask));
             exec.dependsOn(jarTask);
         }

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -348,9 +348,9 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
         project.getDependencies().add(CONFIG_COMPILE, project.fileTree("libs"));
 
         // make MC dependencies into normal compile classpath
-        project.getDependencies().add(CONFIG_COMPILE, project.getConfigurations().getByName(CONFIG_DEPS));
-        project.getDependencies().add(CONFIG_COMPILE, project.getConfigurations().getByName(CONFIG_MC));
-        project.getDependencies().add(CONFIG_RUNTIME, project.getConfigurations().getByName(CONFIG_START));
+        project.getConfigurations().getByName(CONFIG_COMPILE).extendsFrom(project.getConfigurations().getByName(CONFIG_DEPS));
+        project.getConfigurations().getByName(CONFIG_COMPILE).extendsFrom(project.getConfigurations().getByName(CONFIG_MC));
+        project.getConfigurations().getByName(CONFIG_RUNTIME).extendsFrom(project.getConfigurations().getByName(CONFIG_START));
     }
 
     /**

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -4,9 +4,9 @@ import com.google.common.base.Joiner;
 import com.google.common.base.Strings;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.Lists;
 import com.google.common.io.Files;
 import groovy.lang.Closure;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.GradleVersionUtils;
 import net.minecraftforge.gradle.common.BasePlugin;
 import net.minecraftforge.gradle.common.Constants;
@@ -21,7 +21,6 @@ import org.gradle.api.*;
 import org.gradle.api.artifacts.Configuration.State;
 import org.gradle.api.artifacts.dsl.DependencyHandler;
 import org.gradle.api.execution.TaskExecutionGraph;
-import org.gradle.api.file.FileCollection;
 import org.gradle.api.internal.ConventionTask;
 import org.gradle.api.internal.plugins.DslObject;
 import org.gradle.api.logging.Logger;
@@ -35,7 +34,6 @@ import org.gradle.api.tasks.compile.GroovyCompile;
 import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
-import org.gradle.util.DeprecationLogger;
 import org.gradle.util.GUtil;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
@@ -51,7 +49,6 @@ import javax.xml.transform.dom.DOMSource;
 import javax.xml.transform.stream.StreamResult;
 import java.io.File;
 import java.io.IOException;
-import java.util.List;
 
 import static net.minecraftforge.gradle.common.Constants.*;
 import static net.minecraftforge.gradle.user.UserConstants.*;
@@ -1060,8 +1057,8 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
 
             //done in the delayed configuration.
             File out = recomp.call();
-            repackageTask.setArchiveName(out.getName());
-            repackageTask.setDestinationDir(out.getParentFile());
+            ArchiveTaskHelper.setArchiveName(repackageTask, out.getName());
+            ArchiveTaskHelper.setDestinationDir(repackageTask, out.getParentFile());
         }
 
         {
@@ -1091,28 +1088,28 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
         JavaExec exec = (JavaExec) project.getTasks().getByName("runClient");
         {
             exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
-            exec.classpath(jarTask.getArchivePath());
+            exec.classpath(ArchiveTaskHelper.getArchivePath(jarTask));
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("runServer");
         {
             exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
-            exec.classpath(jarTask.getArchivePath());
+            exec.classpath(ArchiveTaskHelper.getArchivePath(jarTask));
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("debugClient");
         {
             exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
-            exec.classpath(jarTask.getArchivePath());
+            exec.classpath(ArchiveTaskHelper.getArchivePath(jarTask));
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("debugServer");
         {
             exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
-            exec.classpath(jarTask.getArchivePath());
+            exec.classpath(ArchiveTaskHelper.getArchivePath(jarTask));
             exec.dependsOn(jarTask);
         }
 

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -58,10 +58,10 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
     @Override
     public void applyPlugin() {
         this.applyExternalPlugin("java");
-        GradleVersionUtils.ifBefore(project, "7.0", new Runnable() {
+        GradleVersionUtils.ifBefore("7.0", new Runnable() {
             @Override
             public void run() {
-                GradleVersionUtils.ifAfter(project, "6.0", new Runnable() {
+                GradleVersionUtils.ifAfter("6.0", new Runnable() {
                     @Override
                     public void run() {
                         if (project.getGradle().getStartParameter().getWarningMode() == WarningMode.All) {

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -36,6 +36,7 @@ import org.gradle.api.tasks.compile.JavaCompile;
 import org.gradle.api.tasks.scala.ScalaCompile;
 import org.gradle.plugins.ide.idea.model.IdeaModel;
 import org.gradle.util.DeprecationLogger;
+import org.gradle.util.GUtil;
 import org.w3c.dom.DOMException;
 import org.w3c.dom.Document;
 import org.w3c.dom.Element;
@@ -344,12 +345,12 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
         project.getDependencies().add(CONFIG_START, project.files(delayedFile(getStartDir())));
 
         // extra libs folder.
-        project.getDependencies().add("compile", project.fileTree("libs"));
+        project.getDependencies().add(CONFIG_COMPILE, project.fileTree("libs"));
 
         // make MC dependencies into normal compile classpath
-        project.getDependencies().add("compile", project.getConfigurations().getByName(CONFIG_DEPS));
-        project.getDependencies().add("compile", project.getConfigurations().getByName(CONFIG_MC));
-        project.getDependencies().add("runtime", project.getConfigurations().getByName(CONFIG_START));
+        project.getDependencies().add(CONFIG_COMPILE, project.getConfigurations().getByName(CONFIG_DEPS));
+        project.getDependencies().add(CONFIG_COMPILE, project.getConfigurations().getByName(CONFIG_MC));
+        project.getDependencies().add(CONFIG_RUNTIME, project.getConfigurations().getByName(CONFIG_START));
     }
 
     /**
@@ -370,8 +371,8 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
         main.setCompileClasspath(main.getCompileClasspath().plus(api.getOutput()));
         test.setCompileClasspath(test.getCompileClasspath().plus(api.getOutput()));
 
-        project.getConfigurations().getByName("apiCompile").extendsFrom(project.getConfigurations().getByName("compile"));
-        project.getConfigurations().getByName("testCompile").extendsFrom(project.getConfigurations().getByName("apiCompile"));
+        project.getConfigurations().getByName(GUtil.toLowerCamelCase("api " + CONFIG_COMPILE)).extendsFrom(project.getConfigurations().getByName(CONFIG_COMPILE));
+        project.getConfigurations().getByName(GUtil.toLowerCamelCase("test " + CONFIG_COMPILE)).extendsFrom(project.getConfigurations().getByName(GUtil.toLowerCamelCase("api " + CONFIG_COMPILE)));
 
         // set compile not to take from libs
         /*
@@ -1089,28 +1090,28 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
 
         JavaExec exec = (JavaExec) project.getTasks().getByName("runClient");
         {
-            exec.classpath(project.getConfigurations().getByName("runtime"));
+            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("runServer");
         {
-            exec.classpath(project.getConfigurations().getByName("runtime"));
+            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("debugClient");
         {
-            exec.classpath(project.getConfigurations().getByName("runtime"));
+            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
         }
 
         exec = (JavaExec) project.getTasks().getByName("debugServer");
         {
-            exec.classpath(project.getConfigurations().getByName("runtime"));
+            exec.classpath(project.getConfigurations().getByName(CONFIG_RUNTIME));
             exec.classpath(jarTask.getArchivePath());
             exec.dependsOn(jarTask);
         }

--- a/src/main/java/net/minecraftforge/gradle/user/UserConstants.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserConstants.java
@@ -13,6 +13,10 @@ public final class UserConstants {
     public static final String CONFIG_DEPS = "minecraftDeps";
     public static final String CONFIG_MC = "minecraft";
 
+    // build configurations. same as in DevConstants
+    public static final String CONFIG_RUNTIME = "runtimeOnly";
+    public static final String CONFIG_COMPILE = "implementation";
+
     static final String FORGE_JAVADOC_URL = Constants.FORGE_MAVEN + "/net/minecraftforge/forge/{API_VERSION}/forge-{API_VERSION}-javadoc.zip";
 
     static final String NATIVES_DIR_OLD = "{BUILD_DIR}/natives";

--- a/src/main/java/net/minecraftforge/gradle/user/UserConstants.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserConstants.java
@@ -15,6 +15,7 @@ public final class UserConstants {
 
     // build configurations. same as in DevConstants
     public static final String CONFIG_RUNTIME = "runtimeOnly";
+    public static final String CONFIG_RUNTIME_CLASSPATH = "runtimeClasspath";
     public static final String CONFIG_COMPILE = "implementation";
 
     static final String FORGE_JAVADOC_URL = Constants.FORGE_MAVEN + "/net/minecraftforge/forge/{API_VERSION}/forge-{API_VERSION}-javadoc.zip";

--- a/src/main/java/net/minecraftforge/gradle/user/lib/LiteLoaderPlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/lib/LiteLoaderPlugin.java
@@ -1,6 +1,7 @@
 package net.minecraftforge.gradle.user.lib;
 
 import com.google.common.base.Throwables;
+import net.minecraftforge.gradle.ArchiveTaskHelper;
 import net.minecraftforge.gradle.GradleConfigurationException;
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import net.minecraftforge.gradle.json.JsonFactory;
@@ -35,7 +36,7 @@ public class LiteLoaderPlugin extends UserLibBasePlugin {
         commonApply();
 
         // change main output to litemod
-        ((Jar) project.getTasks().getByName("jar")).setExtension(EXTENSION);
+        ArchiveTaskHelper.setExtension((Jar) project.getTasks().getByName("jar"), EXTENSION);
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
@@ -77,11 +78,11 @@ public class LiteLoaderPlugin extends UserLibBasePlugin {
         // create apiJar task
         Jar jarTask = makeTask("jar" + cappedApiName, Jar.class);
         jarTask.from(javaConv.getSourceSets().getByName(SourceSet.MAIN_SOURCE_SET_NAME).getOutput());
-        jarTask.setClassifier(actualApiName());
-        jarTask.setExtension(EXTENSION);
+        ArchiveTaskHelper.setClassifier(jarTask, actualApiName());
+        ArchiveTaskHelper.setExtension(jarTask, EXTENSION);
 
         // configure otherPlugin task to have a classifier
-        ((Jar) project.getTasks().getByName("jar")).setClassifier(((UserBasePlugin) otherPlugin).getApiName());
+        ArchiveTaskHelper.setClassifier((Jar) project.getTasks().getByName("jar"), ((UserBasePlugin) otherPlugin).getApiName());
 
         //  configure reobf for litemod
         ((ReobfTask) project.getTasks().getByName("reobf")).reobf(jarTask, new Action<ArtifactSpec>() {


### PR DESCRIPTION
Fixes #9 

Currently, build task runs successfully but deprecated Gradle features are used so I should fix it.

log of build with [ForgeGradle-example](https://github.com/anatawa12/ForgeGradle-example): 
```
anatawa12:~/IdeaProjects/ForgeGradle-example +(gradle6) $ ./gradlew build --warning-mode all

> Configure project :
The BuildListener.buildStarted(Gradle) method has been deprecated. This is scheduled to be removed in Gradle 7.0. Consult the upgrading guide for further information: https://docs.gradle.org/6.7/userguide/upgrading_version_5.html#apis_buildlistener_buildstarted_and_gradle_buildstarted_have_been_deprecated
        at build_42ucah4m3qwxjewdr1nfscau6.run(/Users/anatawa12/IdeaProjects/ForgeGradle-example/build.gradle:28)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The maven plugin has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the maven-publish plugin instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.7/userguide/upgrading_version_5.html#legacy_publication_system_is_deprecated_and_replaced_with_the_publish_plugins
        at build_42ucah4m3qwxjewdr1nfscau6.run(/Users/anatawa12/IdeaProjects/ForgeGradle-example/build.gradle:28)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The compile configuration has been deprecated for dependency declaration. This will fail with an error in Gradle 7.0. Please use the implementation or api configuration instead. Consult the upgrading guide for further information: https://docs.gradle.org/6.7/userguide/upgrading_version_5.html#dependencies_should_no_longer_be_declared_using_the_compile_and_runtime_configurations
        at build_42ucah4m3qwxjewdr1nfscau6.run(/Users/anatawa12/IdeaProjects/ForgeGradle-example/build.gradle:28)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Adding a Configuration as a dependency is a confusing behavior which isn't recommended. This behaviour has been deprecated and is scheduled to be removed in Gradle 8.0. If you're interested in inheriting the dependencies from the Configuration you are adding, you should use Configuration#extendsFrom instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.artifacts.Configuration.html#org.gradle.api.artifacts.Configuration:extendsFrom(org.gradle.api.artifacts.Configuration[]) for more details.
        at build_42ucah4m3qwxjewdr1nfscau6.run(/Users/anatawa12/IdeaProjects/ForgeGradle-example/build.gradle:28)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
Internal API constructor DefaultDomainObjectSet(Class<T>) has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use ObjectFactory.domainObjectSet(Class<T>) instead. See https://docs.gradle.org/6.7/userguide/custom_gradle_types.html#domainobjectset for more details.
        at build_42ucah4m3qwxjewdr1nfscau6.run(/Users/anatawa12/IdeaProjects/ForgeGradle-example/build.gradle:28)
        (Run with --stacktrace to get the full stack trace of this deprecation warning.)
The AbstractArchiveTask.archiveName property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveFileName property instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:archiveName for more details.
The AbstractArchiveTask.destinationDir property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the destinationDirectory property instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:destinationDir for more details.

> Task :getVersionJson
Property 'file' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'url' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'dieWithError' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.

> Task :extractUserDev UP-TO-DATE
Using insecure protocols with repositories has been deprecated. This is scheduled to be removed in Gradle 7.0. Switch Maven repository 'forge(http://files.minecraftforge.net/maven)' to a secure protocol (like HTTPS) or allow insecure protocols. See https://docs.gradle.org/6.7/dsl/org.gradle.api.artifacts.repositories.UrlArtifactRepository.html#org.gradle.api.artifacts.repositories.UrlArtifactRepository:allowInsecureProtocol for more details.

> Task :sourceMainJava UP-TO-DATE
Type 'SourceCopyTask': field 'includes' without corresponding getter has been annotated with @Input. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'incudes' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
The AbstractArchiveTask.baseName property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveBaseName property instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:baseName for more details.
The AbstractArchiveTask.appendix property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveAppendix property instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:appendix for more details.
The AbstractArchiveTask.version property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveVersion property instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:version for more details.
The AbstractArchiveTask.classifier property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveClassifier property instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:classifier for more details.
The AbstractArchiveTask.extension property has been deprecated. This is scheduled to be removed in Gradle 7.0. Please use the archiveExtension property instead. See https://docs.gradle.org/6.7/dsl/org.gradle.api.tasks.bundling.AbstractArchiveTask.html#org.gradle.api.tasks.bundling.AbstractArchiveTask:extension for more details.

> Task :reobf
Property 'filesToObfuscate' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'obfOutput' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'obfuscated' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.
Property 'obfuscatedFiles' is not annotated with an input or output annotation. This behaviour has been deprecated and is scheduled to be removed in Gradle 7.0. See https://docs.gradle.org/6.7/userguide/more_about_tasks.html#sec:up_to_date_checks for more details.

BUILD SUCCESSFUL in 6s
10 actionable tasks: 4 executed, 6 up-to-date
```