### PR TITLE
Update Junit and remove unneeded closure calls

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,7 +101,6 @@ dependencies {
         compileOnly("net.minecraft:launchwrapper:1.11")
     }
 
-    testImplementation("junit:junit:4.+")
     testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
 }
 
@@ -134,9 +133,6 @@ val test by tasks.getting(Test::class) {
     {
         exclude("**/ExtensionMcpMappingTest*")
         exclude("**/ExtensionForgeVersionTest*")
-    }
-    reports {
-        junitXml.required.set(true)
     }
     useJUnitPlatform()
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,10 +22,10 @@ java {
 val gradleStartDev = false
 
 repositories {
+    mavenCentral()
     maven("https://maven.minecraftforge.net") {
         name = "forge"
     }
-    mavenCentral()
     if (gradleStartDev) {
         maven("https://libraries.minecraft.net/") {
             name = "mojang"
@@ -102,6 +102,7 @@ dependencies {
     }
 
     testImplementation("junit:junit:4.+")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.1")
 }
 
 val compileJava by tasks.getting(JavaCompile::class) {
@@ -137,6 +138,7 @@ val test by tasks.getting(Test::class) {
     reports {
         junitXml.required.set(true)
     }
+    useJUnitPlatform()
 }
 
 publishing {

--- a/src/main/java/edu/sc/seis/launch4j/Launch4jPlugin.java
+++ b/src/main/java/edu/sc/seis/launch4j/Launch4jPlugin.java
@@ -1,9 +1,11 @@
 package edu.sc.seis.launch4j;
 
-import groovy.lang.Closure;
 import net.minecraftforge.gradle.GradleVersionUtils;
 import net.minecraftforge.gradle.user.UserConstants;
-import org.gradle.api.*;
+import org.gradle.api.DefaultTask;
+import org.gradle.api.Plugin;
+import org.gradle.api.Project;
+import org.gradle.api.Task;
 import org.gradle.api.file.CopySpec;
 import org.gradle.api.plugins.JavaPlugin;
 import org.gradle.api.tasks.Exec;
@@ -12,6 +14,7 @@ import org.gradle.api.tasks.bundling.Jar;
 
 import java.io.File;
 import java.util.HashMap;
+import java.util.concurrent.Callable;
 
 public class Launch4jPlugin implements Plugin<Project> {
 
@@ -63,19 +66,15 @@ public class Launch4jPlugin implements Plugin<Project> {
         return task;
     }
 
-    @SuppressWarnings("serial")
     private Task addCopyToLibTask(Project project, Launch4jPluginExtension configuration) {
         final Sync task = makeTask(TASK_LIB_COPY_NAME, Sync.class);
         task.setDescription("Copies the project dependency jars in the lib directory.");
         task.setGroup(LAUNCH4J_GROUP);
         // more stuff with the java plugin
         //task.with(configureDistSpec(project));
-        task.into(new Closure<File>(null) {
-            @Override
-            public File call(Object... obj) {
-                Launch4jPluginExtension ext = ((Launch4jPluginExtension) task.getProject().getExtensions().getByName(Launch4jPlugin.LAUNCH4J_CONFIGURATION_NAME));
-                return task.getProject().file(task.getProject().getBuildDir() + "/" + ext.getOutputDir() + "/lib");
-            }
+        task.into((Callable<File>) () -> {
+            Launch4jPluginExtension ext = ((Launch4jPluginExtension) task.getProject().getExtensions().getByName(Launch4jPlugin.LAUNCH4J_CONFIGURATION_NAME));
+            return task.getProject().file(task.getProject().getBuildDir() + "/" + ext.getOutputDir() + "/lib");
         });
         return task;
     }
@@ -101,9 +100,9 @@ public class Launch4jPlugin implements Plugin<Project> {
         return task;
     }
 
-    @SuppressWarnings({"serial", "unused"})
+    @SuppressWarnings({"unused"})
     private CopySpec configureDistSpec(Project project) {
-        CopySpec distSpec = project.copySpec(new Closure<Object>(null) {});
+        CopySpec distSpec = project.copySpec();
         Jar jar = (Jar) project.getTasks().getByName(JavaPlugin.JAR_TASK_NAME);
 
         distSpec.from(jar);

--- a/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
+++ b/src/main/java/net/minecraftforge/gradle/GradleVersionUtils.java
@@ -2,6 +2,8 @@ package net.minecraftforge.gradle;
 
 import org.gradle.util.GradleVersion;
 
+import java.util.function.Supplier;
+
 public class GradleVersionUtils {
     public static void checkSupportedVersion() {
         GradleVersionUtils.ifBefore("4.0", () -> {
@@ -34,15 +36,16 @@ public class GradleVersionUtils {
             action.run();
         }
     }
+
     /**
      * same version includes after
      * @param versionName includes this version
      */
-    public static <T> T choose(String versionName, Callable<? extends T> before, Callable<? extends T> after) {
+    public static <T> T choose(String versionName, Supplier<? extends T> before, Supplier<? extends T> after) {
         if (isBefore(versionName)) {
-            return before.call();
+            return before.get();
         } else {
-            return after.call();
+            return after.get();
         }
     }
 
@@ -55,9 +58,5 @@ public class GradleVersionUtils {
         GradleVersion version = GradleVersion.version(versionName);
 
         return gradleVersion.compareTo(version) < 0;
-    }
-
-    public interface Callable<T> {
-        T call();
     }
 }

--- a/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/common/BasePlugin.java
@@ -255,7 +255,7 @@ public abstract class BasePlugin<K extends BaseExtension> implements Plugin<Proj
                 // requires before the jcenter
                 if (mvnRepo.getUrl().toString().contains("//files.minecraftforge.net/maven"))
                     return false;
-                if (mvnRepo.getUrl().toString().equals("https://maven.minecraftforge.net/"))
+                if (mvnRepo.getUrl().toString().contains("//maven.minecraftforge.net"))
                     return true;
             }
         }

--- a/src/main/java/net/minecraftforge/gradle/common/Constants.java
+++ b/src/main/java/net/minecraftforge/gradle/common/Constants.java
@@ -5,6 +5,8 @@ import groovy.lang.Closure;
 import net.minecraftforge.gradle.StringUtils;
 import net.minecraftforge.gradle.json.version.OS;
 import org.gradle.api.Project;
+import org.gradle.api.Task;
+import org.gradle.api.specs.Spec;
 
 import java.io.File;
 import java.io.FileNotFoundException;
@@ -39,12 +41,18 @@ public class Constants {
     public static final String EXT_NAME_MC = "minecraft";
     public static final String EXT_NAME_JENKINS = "jenkins";
 
+    /**
+     * @deprecated unused
+     */
     @SuppressWarnings("serial")
+    @Deprecated
     public static final Closure<Boolean> CALL_FALSE = new Closure<Boolean>(null) {
         public Boolean call(Object o) {
             return false;
         }
     };
+
+    public static final Spec<? super Task> SPEC_FALSE = e -> false;
 
     // urls
     /** @deprecated AWS s3 Minecraft.Download is not live */
@@ -221,8 +229,16 @@ public class Constants {
         return null;
     }
 
+    /**
+     * @deprecated breaks task cache
+     */
+    @Deprecated
     public static PrintStream getTaskLogStream(Project project, String name) {
-        final File taskLogs = new File(project.getBuildDir(), "taskLogs");
+        return getTaskLogStream(project.getBuildDir(), name);
+    }
+
+    public static PrintStream getTaskLogStream(File buildDir, String name) {
+        final File taskLogs = new File(buildDir, "taskLogs");
         taskLogs.mkdirs();
         final File logFile = new File(taskLogs, name);
         logFile.delete(); //Delete the old log
@@ -231,6 +247,7 @@ public class Constants {
         } catch (FileNotFoundException ignored) {}
         return null; // Should never get to here
     }
+
 
     /**
      * Throws a null runtime exception if the resource isnt found.

--- a/src/main/java/net/minecraftforge/gradle/delayed/DelayedBase.java
+++ b/src/main/java/net/minecraftforge/gradle/delayed/DelayedBase.java
@@ -5,11 +5,13 @@ import net.minecraftforge.gradle.common.BaseExtension;
 import net.minecraftforge.gradle.common.JenkinsExtension;
 import org.gradle.api.Project;
 
+import java.util.function.Supplier;
+
 import static net.minecraftforge.gradle.common.Constants.EXT_NAME_JENKINS;
 import static net.minecraftforge.gradle.common.Constants.EXT_NAME_MC;
 
 @SuppressWarnings("serial")
-public abstract class DelayedBase<V> extends Closure<V> {
+public abstract class DelayedBase<V> extends Closure<V> implements Supplier<V> {
     protected Project project;
     private V resolved;
     protected String pattern;
@@ -39,6 +41,11 @@ public abstract class DelayedBase<V> extends Closure<V> {
         }
 
         return resolved;
+    }
+
+    @Override
+    public final V get() {
+        return call();
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/gradle/tasks/ApplyS2STask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ApplyS2STask.java
@@ -30,10 +30,12 @@ public class ApplyS2STask extends DefaultTask {
     private final File buildDir = getProject().getBuildDir();
 
     @InputFile
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     private DelayedFile rangeMap;
 
     @Optional
     @InputFile
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     private DelayedFile excModifiers;
 
     // stuff defined on the tasks..
@@ -244,11 +246,13 @@ public class ApplyS2STask extends DefaultTask {
     }
 
     @InputFiles
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     public FileCollection getIns() {
         return createFileCollection(in);
     }
 
     @InputFiles
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     public List<File> getIn() {
         List<File> files = new LinkedList<>();
         for (DelayedFile f : in)
@@ -279,6 +283,7 @@ public class ApplyS2STask extends DefaultTask {
     }
 
     @InputFiles
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     public FileCollection getSrgs() {
         return createFileCollection(srg);
     }
@@ -296,6 +301,7 @@ public class ApplyS2STask extends DefaultTask {
     }
 
     @InputFiles
+    @PathSensitive(PathSensitivity.ABSOLUTE)
     public FileCollection getExcs() {
         return createFileCollection(exc);
     }

--- a/src/main/java/net/minecraftforge/gradle/tasks/DownloadAssetsTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/DownloadAssetsTask.java
@@ -22,11 +22,12 @@ import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Map.Entry;
 import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.function.Supplier;
 
 public class DownloadAssetsTask extends DefaultTask {
     DelayedFile assetsDir;
 
-    Closure<AssetIndex> index;
+    Supplier<AssetIndex> index;
 
     @Input
     DelayedString indexName;
@@ -138,10 +139,18 @@ public class DownloadAssetsTask extends DefaultTask {
 
     @Input
     public AssetIndex getIndex() {
-        return index.call();
+        return index.get();
     }
 
+    /**
+     * @deprecated use {@link #setIndex(Supplier)} variant
+     */
+    @Deprecated
     public void setIndex(Closure<AssetIndex> index) {
+        this.index = index::call;
+    }
+
+    public void setIndex(Supplier<AssetIndex> index) {
         this.index = index;
     }
 

--- a/src/main/java/net/minecraftforge/gradle/tasks/DownloadAssetsTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/DownloadAssetsTask.java
@@ -146,7 +146,7 @@ public class DownloadAssetsTask extends DefaultTask {
      * @deprecated use {@link #setIndex(Supplier)} variant
      */
     @Deprecated
-    public void setIndex(Closure<AssetIndex> index) {
+    public void setIndex(@Deprecated Closure<AssetIndex> index) {
         this.index = index::call;
     }
 

--- a/src/main/java/net/minecraftforge/gradle/tasks/GenWrapperArtifactTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/GenWrapperArtifactTask.java
@@ -12,6 +12,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.function.BooleanSupplier;
 
 import static net.minecraftforge.gradle.user.UserConstants.WRAPPER_ARTIFACT_GROUP_ID;
 
@@ -26,7 +27,7 @@ public class GenWrapperArtifactTask extends DefaultTask {
     DelayedString moduleName;
 
     @Input
-    DelayedBase<Boolean> isDecomp;
+    BooleanSupplier isDecomp;
 
     @Input
     DelayedString srcDepName;
@@ -80,21 +81,23 @@ public class GenWrapperArtifactTask extends DefaultTask {
     }
 
     public boolean getIsDecomp() {
-        return isDecomp.call();
+        return isDecomp.getAsBoolean();
     }
 
+    /**
+     * @deprecated use {@link #setIsDecomp(BooleanSupplier)} variant
+     */
+    @Deprecated
     public void setIsDecomp(DelayedBase<Boolean> isDecomp) {
+        this.isDecomp = isDecomp::call;
+    }
+
+    public void setIsDecomp(BooleanSupplier isDecomp) {
         this.isDecomp = isDecomp;
     }
 
-    
     public void setIsDecomp(final boolean isDecomp) {
-        this.isDecomp = new DelayedBase<Boolean>(null, null) {
-            @Override
-            public Boolean resolveDelayed() {
-                return isDecomp;
-            }
-        };
+        this.isDecomp = () -> isDecomp;
     }
 
     public String getSrcDepName() {

--- a/src/main/java/net/minecraftforge/gradle/tasks/ObtainFernFlowerTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ObtainFernFlowerTask.java
@@ -6,7 +6,6 @@ import net.minecraftforge.gradle.StringUtils;
 import net.minecraftforge.gradle.common.Constants;
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import net.minecraftforge.gradle.delayed.DelayedString;
-import net.minecraftforge.gradle.tasks.abstractutil.CachedTask;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.CacheableTask;
 import org.gradle.api.tasks.Input;

--- a/src/main/java/net/minecraftforge/gradle/tasks/ProcessJarTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ProcessJarTask.java
@@ -12,6 +12,7 @@ import net.minecraftforge.gradle.json.MCInjectorStruct;
 import net.minecraftforge.gradle.json.MCInjectorStruct.InnerClass;
 import net.minecraftforge.gradle.tasks.abstractutil.CachedTask;
 import org.gradle.api.file.FileCollection;
+import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.tasks.Optional;
 import org.gradle.api.tasks.*;
 import org.objectweb.asm.ClassReader;
@@ -33,6 +34,7 @@ import static net.minecraftforge.gradle.common.Constants.EXT_NAME_MC;
 import static org.objectweb.asm.Opcodes.*;
 
 public class ProcessJarTask extends CachedTask {
+    private final ExtensionContainer extensions = getProject().getExtensions();
     @InputFile
     @Optional
     private DelayedFile fieldCsv;
@@ -266,7 +268,7 @@ public class ProcessJarTask extends CachedTask {
             Files.write(jsonTmp.toPath(), JsonFactory.GSON.toJson(struct).getBytes());
         }
 
-        BaseExtension exten = (BaseExtension) getProject().getExtensions().getByName(EXT_NAME_MC);
+        BaseExtension exten = (BaseExtension) extensions.getByName(EXT_NAME_MC);
         boolean genParams = !exten.getVersion().equals("1.7.2");
         getLogger().debug("INPUT: " + inJar);
         getLogger().debug("OUTPUT: " + outJar);

--- a/src/main/java/net/minecraftforge/gradle/tasks/abstractutil/ExtractTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/abstractutil/ExtractTask.java
@@ -187,7 +187,6 @@ public class ExtractTask extends DefaultTask {
         throw new IllegalStateException("must be injected");
     }
 
-
     public boolean isIncludeEmptyDirs() {
         return includeEmptyDirs;
     }

--- a/src/main/java/net/minecraftforge/gradle/tasks/abstractutil/FileFilterTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/abstractutil/FileFilterTask.java
@@ -26,7 +26,7 @@ public class FileFilterTask extends DefaultTask {
     ArrayList<MapEntry> replacements = new ArrayList<>();
 
     public FileFilterTask() {
-        this.getOutputs().upToDateWhen(Constants.CALL_FALSE);
+        this.getOutputs().upToDateWhen(Constants.SPEC_FALSE);
     }
 
     @TaskAction

--- a/src/main/java/net/minecraftforge/gradle/tasks/dev/SubmoduleChangelogTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/dev/SubmoduleChangelogTask.java
@@ -1,13 +1,11 @@
 package net.minecraftforge.gradle.tasks.dev;
 
-import groovy.lang.Closure;
 import net.minecraftforge.gradle.delayed.DelayedFile;
 import org.gradle.api.DefaultTask;
 import org.gradle.api.tasks.Input;
 import org.gradle.api.tasks.InputDirectory;
 import org.gradle.api.tasks.OutputFile;
 import org.gradle.api.tasks.TaskAction;
-import org.gradle.process.ExecSpec;
 
 import java.io.BufferedWriter;
 import java.io.ByteArrayOutputStream;
@@ -70,20 +68,14 @@ public class SubmoduleChangelogTask extends DefaultTask {
         getLogger().lifecycle("");
     }
 
-    @SuppressWarnings("serial")
     private String[] runGit(final File dir, final String... args) {
         final ByteArrayOutputStream out = new ByteArrayOutputStream();
 
-        getProject().exec(new Closure<ExecSpec>(getProject(), getProject()) {
-            @Override
-            public ExecSpec call() {
-                ExecSpec exec = (ExecSpec) getDelegate();
-                exec.setExecutable("git");
-                exec.args((Object[]) args);
-                exec.setStandardOutput(out);
-                exec.setWorkingDir(dir);
-                return exec;
-            }
+        getProject().exec(exec -> {
+            exec.setExecutable("git");
+            exec.args((Object[]) args);
+            exec.setStandardOutput(out);
+            exec.setWorkingDir(dir);
         });
 
         return out.toString().trim().split("\n");

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
@@ -16,6 +16,7 @@ import org.gradle.api.artifacts.Configuration;
 import org.gradle.api.artifacts.PublishArtifact;
 import org.gradle.api.file.FileCollection;
 import org.gradle.api.model.ObjectFactory;
+import org.gradle.api.plugins.ExtensionContainer;
 import org.gradle.api.tasks.*;
 import org.gradle.api.tasks.bundling.AbstractArchiveTask;
 
@@ -33,6 +34,7 @@ public class ReobfTask extends DefaultTask {
     final private DomainObjectSet<ObfArtifact> obfOutput = GradleVersionUtils.choose("5.5",
             ReobfTask::getInternalDeprecatedDefaultDomain,
             () -> getInjectedObjectFactory().domainObjectSet(ObfArtifact.class));
+    private final ExtensionContainer extensions = getProject().getExtensions();
 
     @SuppressWarnings("unchecked")
     private static DomainObjectSet<ObfArtifact> getInternalDeprecatedDefaultDomain() {
@@ -92,7 +94,15 @@ public class ReobfTask extends DefaultTask {
     }
 
     public void reobf(Task task, Action<ArtifactSpec> artifactSpec) {
-        reobf(task, new ActionClosure(artifactSpec));
+        if (!(task instanceof AbstractArchiveTask)) {
+            throw new InvalidUserDataException("You cannot reobfuscate tasks that are not 'archive' tasks, such as 'jar', 'zip' etc. (you tried to sign $task)");
+        }
+
+        ArtifactSpec spec = new ArtifactSpec((AbstractArchiveTask) task);
+        artifactSpec.execute(spec);
+
+        dependsOn(task);
+        addArtifact(new ObfArtifact(new DelayedThingy(task), spec, this));
     }
 
     public void reobf(Task task, Closure<Object> artifactSpec) {
@@ -123,8 +133,12 @@ public class ReobfTask extends DefaultTask {
         }
     }
 
-    public void reobf(PublishArtifact art, Action<ArtifactSpec> artifactSpec) {
-        reobf(art, new ActionClosure(artifactSpec));
+    public void reobf(PublishArtifact publishArtifact, Action<ArtifactSpec> artifactSpec) {
+        ArtifactSpec spec = new ArtifactSpec(publishArtifact, getProject());
+        artifactSpec.execute(spec);
+
+        dependsOn(publishArtifact);
+        addArtifact(new ObfArtifact(publishArtifact, spec, this));
     }
 
     /**
@@ -154,7 +168,10 @@ public class ReobfTask extends DefaultTask {
     }
 
     public void reobf(File file, Action<ArtifactSpec> artifactSpec) {
-        reobf(file, new ActionClosure(artifactSpec));
+        ArtifactSpec spec = new ArtifactSpec(file, getProject());
+        artifactSpec.execute(spec);
+
+        addArtifact(new ObfArtifact(file, spec, this));
     }
 
     /**
@@ -248,7 +265,7 @@ public class ReobfTask extends DefaultTask {
         File srg = Files.createTempFile(getTemporaryDir().toPath(), "reobf-default", ".srg").toFile();
         File extraSrg = Files.createTempFile(getTemporaryDir().toPath(), "reobf-extra", ".srg").toFile();
 
-        UserExtension ext = (UserExtension) getProject().getExtensions().getByName(Constants.EXT_NAME_MC);
+        UserExtension ext = (UserExtension) extensions.getByName(Constants.EXT_NAME_MC);
 
         if (ext.isDecomp()) {
             exc = getExceptor();
@@ -336,22 +353,6 @@ public class ReobfTask extends DefaultTask {
         return getProject().files(collect);
     }
 
-    @SuppressWarnings({"serial"})
-    private class ActionClosure extends Closure<Object> {
-        private final Action<ArtifactSpec> act;
-
-        public ActionClosure(Action<ArtifactSpec> artifactSpec) {
-            super(null);
-            this.act = artifactSpec;
-        }
-
-        @Override
-        public ArtifactSpec call(Object obj) {
-            act.execute((ArtifactSpec) obj);
-            return null;
-        }
-    }
-
     public boolean getUseRetroGuard() {
         return useRetroGuard;
     }
@@ -437,11 +438,11 @@ public class ReobfTask extends DefaultTask {
     }
 
     public void setSrgSrg() {
-        this.srg = new DelayedFile(getProject(), UserConstants.REOBF_SRG, ((UserExtension) getProject().getExtensions().getByName(Constants.EXT_NAME_MC)).plugin);
+        this.srg = new DelayedFile(getProject(), UserConstants.REOBF_SRG, ((UserExtension) extensions.getByName(Constants.EXT_NAME_MC)).plugin);
     }
 
     public void setSrgMcp() {
-        this.srg = new DelayedFile(getProject(), UserConstants.REOBF_NOTCH_SRG, ((UserExtension) getProject().getExtensions().getByName(Constants.EXT_NAME_MC)).plugin);
+        this.srg = new DelayedFile(getProject(), UserConstants.REOBF_NOTCH_SRG, ((UserExtension) extensions.getByName(Constants.EXT_NAME_MC)).plugin);
     }
 
     public File getFieldCsv() {

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
@@ -27,6 +27,7 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 
 public class ReobfTask extends DefaultTask {
     final private DomainObjectSet<ObfArtifact> obfOutput = GradleVersionUtils.choose("5.5",
@@ -78,21 +79,11 @@ public class ReobfTask extends DefaultTask {
 
     private List<Object> extraSrgFiles = new ArrayList<>();
 
-    @SuppressWarnings("serial")
     public ReobfTask() {
         super();
 
-        getInputs().files(new Closure<Object>(obfOutput) {
-            public Object call(Object... objects) {
-                return getFilesToObfuscate();
-            }
-        });
-
-        getOutputs().files(new Closure<Object>(obfOutput) {
-            public Object call(Object... objects) {
-                return getObfuscatedFiles();
-            }
-        });
+        getInputs().files((Callable<FileCollection>) this::getFilesToObfuscate);
+        getOutputs().files((Callable<FileCollection>) this::getObfuscatedFiles);
     }
 
     @Inject

--- a/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/UserBasePlugin.java
@@ -97,7 +97,7 @@ public abstract class UserBasePlugin<T extends UserExtension> extends BasePlugin
 
         Task task = makeTask("setupCIWorkspace", DefaultTask.class);
         task.dependsOn("genSrgs", "deobfBinJar");
-        task.setDescription("Sets up the bare minimum to build a minecraft mod. Idea for CI servers");
+        task.setDescription("Sets up the bare minimum to build a minecraft mod. Ideal for CI servers");
         task.setGroup("ForgeGradle");
         if (wrapperArtifact) task.dependsOn("genWrapperArtifact");
         //configureCISetup(task);

--- a/src/main/java/net/minecraftforge/gradle/user/patch/UserPatchBasePlugin.java
+++ b/src/main/java/net/minecraftforge/gradle/user/patch/UserPatchBasePlugin.java
@@ -323,7 +323,7 @@ public abstract class UserPatchBasePlugin extends UserBasePlugin<UserPatchExtens
         super.configurePostDecomp(decomp, remove);
 
         if (decomp && remove) {
-            (project.getTasks().getByName("applyBinPatches")).onlyIf(Constants.CALL_FALSE);
+            project.getTasks().getByName("applyBinPatches").onlyIf(Constants.SPEC_FALSE);
         }
     }
 }

--- a/src/test/java/net/minecraftforge/gradle/EnumFixerTest.java
+++ b/src/test/java/net/minecraftforge/gradle/EnumFixerTest.java
@@ -2,8 +2,8 @@ package net.minecraftforge.gradle;
 
 import com.google.common.io.Resources;
 import net.minecraftforge.gradle.extrastuff.FFPatcher;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
@@ -23,11 +23,11 @@ public class EnumFixerTest {
         String[] expected = readResource(EXPECTED).split("\r\n|\r|\n");
         String[] actual = input.split("\r\n|\r|\n");
 
-        Assert.assertEquals(expected.length, actual.length);
+        Assertions.assertEquals(expected.length, actual.length);
         for (int i = 0; i < expected.length; i++) {
             //System.out.println("EXPECTED >>"+expected[i]);
             //System.out.println("ACTUAL   >>"+actual[i]);
-            Assert.assertEquals(expected[i], actual[i]);
+            Assertions.assertEquals(expected[i], actual[i]);
         }
     }
 

--- a/src/test/java/net/minecraftforge/gradle/ExtensionForgeVersionTest.java
+++ b/src/test/java/net/minecraftforge/gradle/ExtensionForgeVersionTest.java
@@ -5,20 +5,20 @@ import net.minecraftforge.gradle.user.patch.ForgeUserPlugin;
 import net.minecraftforge.gradle.user.patch.UserPatchExtension;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.BeforeEach;
 
 import java.io.IOException;
 import java.nio.file.Files;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 public class ExtensionForgeVersionTest {
     private Project testProject;
     private UserPatchExtension ext;
 
-    @Before
+    @BeforeEach
     public void setupProject() throws IOException {
         this.testProject = ProjectBuilder.builder()
                 .withName("testProject")

--- a/src/test/java/net/minecraftforge/gradle/ExtensionMcpMappingTest.java
+++ b/src/test/java/net/minecraftforge/gradle/ExtensionMcpMappingTest.java
@@ -5,17 +5,16 @@ import net.minecraftforge.gradle.user.patch.ForgeUserPlugin;
 import net.minecraftforge.gradle.user.patch.UserPatchExtension;
 import org.gradle.api.Project;
 import org.gradle.testfixtures.ProjectBuilder;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.*;
 
 public class ExtensionMcpMappingTest {
     private Project testProject;
     private UserPatchExtension ext;
 
-    @Before
+    @BeforeEach
     public void setupProject() {
         this.testProject = ProjectBuilder.builder().build();
         assertNotNull(this.testProject);
@@ -76,16 +75,20 @@ public class ExtensionMcpMappingTest {
         assertEquals(this.ext.getMappingsVersion(), "12");
     }
 
-    @Test(expected = GradleConfigurationException.class)
+    @Test
     public void testInvalidSnapshot17() {
-        this.ext.setVersion(VERSION_17);
-        this.ext.setMappings("snapshot_20141205");
+        assertThrows(GradleConfigurationException.class, () -> {
+            this.ext.setVersion(VERSION_17);
+            this.ext.setMappings("snapshot_20141205");
+        });
     }
 
-    @Test(expected = GradleConfigurationException.class)
+    @Test
     public void testInvalidSnapshot18() {
-        this.ext.setVersion(VERSION_18);
-        this.ext.setMappings("snapshot_20140909");
+        assertThrows(GradleConfigurationException.class, () -> {
+            this.ext.setVersion(VERSION_18);
+            this.ext.setMappings("snapshot_20140909");
+        });
     }
 
     @Test
@@ -96,22 +99,28 @@ public class ExtensionMcpMappingTest {
         assertEquals(this.ext.getMappingsVersion(), "20140925");
     }
 
-    @Test(expected = GradleConfigurationException.class)
+    @Test
     public void testInvalidSnapshot() {
-        this.ext.setVersion(VERSION_17);
-        this.ext.setMappings("snapshot_15");
+        assertThrows(GradleConfigurationException.class, () -> {
+            this.ext.setVersion(VERSION_17);
+            this.ext.setMappings("snapshot_15");
+        });
     }
 
-    @Test(expected = GradleConfigurationException.class)
+    @Test
     public void testInvalidStable() {
-        this.ext.setVersion(VERSION_17);
-        this.ext.setMappings("stable_20140925");
+        assertThrows(GradleConfigurationException.class, () -> {
+            this.ext.setVersion(VERSION_17);
+            this.ext.setMappings("stable_20140925");
+        });
     }
 
-    @Test(expected = GradleConfigurationException.class)
+    @Test
     public void testInvalidCustom() {
-        this.ext.setVersion(VERSION_17);
-        this.ext.setMappings("abrar_blahblah");
+        assertThrows(GradleConfigurationException.class, () -> {
+            this.ext.setVersion(VERSION_17);
+            this.ext.setMappings("abrar_blahblah");
+        });
     }
 
     @Test

--- a/src/test/java/net/minecraftforge/gradle/FmlCleanupTest.java
+++ b/src/test/java/net/minecraftforge/gradle/FmlCleanupTest.java
@@ -2,8 +2,8 @@ package net.minecraftforge.gradle;
 
 import com.google.common.io.ByteStreams;
 import net.minecraftforge.gradle.extrastuff.FmlCleanup;
-import org.junit.Assert;
-import org.junit.Test;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -21,11 +21,11 @@ public class FmlCleanupTest {
         String[] expected = readResource(EXPECTED).split("\r\n|\r|\n");
         String[] actual = input.split("\r\n|\r|\n");
 
-        //Assert.assertEquals(expected.length, actual.length);
+        //Assertions.assertEquals(expected.length, actual.length);
         for (int i = 0; i < expected.length; i++) {
             System.out.println("EXPECTED >>" + expected[i]);
             System.out.println("ACTUAL   >>" + actual[i]);
-            Assert.assertEquals(expected[i], actual[i]);
+            Assertions.assertEquals(expected[i], actual[i]);
         }
     }
 

--- a/src/test/java/net/minecraftforge/gradle/MultiDirSupplierTest.java
+++ b/src/test/java/net/minecraftforge/gradle/MultiDirSupplierTest.java
@@ -3,10 +3,10 @@ package net.minecraftforge.gradle;
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
 import net.minecraftforge.srg2source.util.io.InputSupplier;
-import org.junit.After;
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
@@ -21,7 +21,7 @@ public class MultiDirSupplierTest {
     private final Random rand = new Random();
     private static final String END = ".tmp";
 
-    @Before // before each test
+    @BeforeEach // before each test
     public void setup() throws IOException {
         int dirNum = rand.nextInt(4) + 1; // 0-5
 
@@ -38,7 +38,7 @@ public class MultiDirSupplierTest {
         }
     }
 
-    @After // after each test
+    @AfterEach // after each test
     public void cleanup() {
         // delete the files.
         for (File f : dirs)
@@ -75,7 +75,7 @@ public class MultiDirSupplierTest {
 
         // gather all the relative paths
         for (String rel : supp.gatherAll(END)) {
-            Assert.assertTrue(expectedFiles.containsValue(rel));
+            Assertions.assertTrue(expectedFiles.containsValue(rel));
         }
 
         supp.close(); // to please the compiler..
@@ -87,7 +87,7 @@ public class MultiDirSupplierTest {
 
         for (File dir : expectedFiles.keySet()) {
             for (String rel : expectedFiles.get(dir)) {
-                Assert.assertEquals(dir, new File(supp.getRoot(rel)).getCanonicalFile());
+                Assertions.assertEquals(dir, new File(supp.getRoot(rel)).getCanonicalFile());
             }
         }
 
@@ -127,7 +127,7 @@ public class MultiDirSupplierTest {
             stream.read(actual);
             stream.close();
 
-            Assert.assertArrayEquals(expected, actual);
+            Assertions.assertArrayEquals(expected, actual);
         }
 
         supp.close(); // to please the compiler..


### PR DESCRIPTION
This pull includes:
- Update junit 4 to junit 5
- Remove/Replace Groovy's Closure with alternatives
- Now DelayedBase extend Supplier
- Replace GradleVersionUtils.Callable with Supplier
- Make more tasks cacheable
- Fix slash bug(Possibly Closes #152)