### PR TITLE
fix: #211;

### DIFF
--- a/src/main/java/net/minecraftforge/gradle/extrastuff/ReobfExceptor.java
+++ b/src/main/java/net/minecraftforge/gradle/extrastuff/ReobfExceptor.java
@@ -24,7 +24,6 @@ public class ReobfExceptor {
     public File methodCSV;
     public File fieldCSV;
     public File excConfig;
-    public boolean copyEmptyDirectories; // Only for SpecialSource
 
     // state stuff
     Map<String, String> clsMap = new HashMap<>();

--- a/src/main/java/net/minecraftforge/gradle/extrastuff/ReobfExceptor.java
+++ b/src/main/java/net/minecraftforge/gradle/extrastuff/ReobfExceptor.java
@@ -24,6 +24,7 @@ public class ReobfExceptor {
     public File methodCSV;
     public File fieldCSV;
     public File excConfig;
+    public boolean copyEmptyDirectories; // Only for SpecialSource
 
     // state stuff
     Map<String, String> clsMap = new HashMap<>();

--- a/src/main/java/net/minecraftforge/gradle/tasks/ProcessJarTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/ProcessJarTask.java
@@ -60,6 +60,9 @@ public class ProcessJarTask extends CachedTask {
     @Input
     private boolean applyMarkers = false;
 
+    @Input
+    private boolean copyEmptyDirectories = false;
+
     private DelayedFile outCleanJar; // clean = pure forge, or pure FML
     private DelayedFile outDirtyJar = new DelayedFile(getProject(), "{BUILD_DIR}/processed.jar"); // dirty = has any other ATs
 
@@ -193,7 +196,7 @@ public class ProcessJarTask extends CachedTask {
         RemapperProcessor atProcessor = new RemapperProcessor(null, null, accessMap);
         // make remapper
         JarRemapper remapper = new JarRemapper(srgProcessor, mapping, atProcessor);
-        remapper.setCopyEmptyDirectories(false);
+        remapper.setCopyEmptyDirectories(copyEmptyDirectories);
 
         // load jar
         Jar input = Jar.init(inJar);
@@ -462,6 +465,14 @@ public class ProcessJarTask extends CachedTask {
 
     public void setMethodCsv(DelayedFile methodCsv) {
         this.methodCsv = methodCsv;
+    }
+
+    public boolean getCopyEmptyDirectories() {
+        return copyEmptyDirectories;
+    }
+
+    public void setCopyEmptyDirectories(boolean copyEmptyDirectories) {
+        this.copyEmptyDirectories = copyEmptyDirectories;
     }
 
     @Override

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ObfArtifact.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ObfArtifact.java
@@ -309,7 +309,7 @@ public class ObfArtifact implements PublishArtifact {
      *
      * @throws InvalidUserDataException if the there is insufficient information available to generate the signature.
      */
-    void generate(ReobfExceptor exc, File defaultSrg, File extraSrg, FileCollection extraSrgFiles) throws Exception {
+    void generate(ReobfExceptor exc, File defaultSrg, File extraSrg, FileCollection extraSrgFiles, boolean copyEmptyDirectories) throws Exception {
         File toObf = getToObf();
         if (toObf == null) {
             throw new InvalidUserDataException("Unable to obfuscate as the file to obfuscate has not been specified");
@@ -338,7 +338,7 @@ public class ObfArtifact implements PublishArtifact {
         if (caller.getUseRetroGuard())
             applyRetroGuard(toObfTemp, toInjectTemp, srg, extraSrg, extraSrgFiles);
         else
-            applySpecialSource(toObfTemp, toInjectTemp, srg, extraSrg, extraSrgFiles, exc != null && exc.copyEmptyDirectories);
+            applySpecialSource(toObfTemp, toInjectTemp, srg, extraSrg, extraSrgFiles, copyEmptyDirectories);
 
         // inject mcVersion!
         if (caller.getMcVersion().startsWith("1.8")) {

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ObfArtifact.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ObfArtifact.java
@@ -338,7 +338,7 @@ public class ObfArtifact implements PublishArtifact {
         if (caller.getUseRetroGuard())
             applyRetroGuard(toObfTemp, toInjectTemp, srg, extraSrg, extraSrgFiles);
         else
-            applySpecialSource(toObfTemp, toInjectTemp, srg, extraSrg, extraSrgFiles);
+            applySpecialSource(toObfTemp, toInjectTemp, srg, extraSrg, extraSrgFiles, exc != null && exc.copyEmptyDirectories);
 
         // inject mcVersion!
         if (caller.getMcVersion().startsWith("1.8")) {
@@ -356,7 +356,7 @@ public class ObfArtifact implements PublishArtifact {
         System.gc(); // clean anything out.. I hope..
     }
 
-    private void applySpecialSource(File input, File output, File srg, File extraSrg, FileCollection extraSrgFiles) throws IOException {
+    private void applySpecialSource(File input, File output, File srg, File extraSrg, FileCollection extraSrgFiles, boolean copyEmptyDirectories) throws IOException {
         // load mapping
         JarMapping mapping = new JarMapping();
         mapping.loadMappings(srg);
@@ -368,7 +368,7 @@ public class ObfArtifact implements PublishArtifact {
 
         // make remapper
         JarRemapper remapper = new JarRemapper(null, mapping);
-        remapper.setCopyEmptyDirectories(false);
+        remapper.setCopyEmptyDirectories(copyEmptyDirectories);
 
         // load jar
         Jar inputJar = Jar.init(input);

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
@@ -79,6 +79,9 @@ public class ReobfTask extends DefaultTask {
     @Input
     private List<String> extraSrg = new ArrayList<>();
 
+    @Input
+    private boolean copyEmptyDirectories = false;
+
     private List<Object> extraSrgFiles = new ArrayList<>();
 
     public ReobfTask() {
@@ -305,6 +308,7 @@ public class ReobfTask extends DefaultTask {
         exc.excConfig = getExceptorCfg();
         exc.fieldCSV = getFieldCsv();
         exc.methodCSV = getMethodCsv();
+        exc.copyEmptyDirectories = getCopyEmptyDirectories();
 
         exc.doFirstThings();
 
@@ -459,6 +463,14 @@ public class ReobfTask extends DefaultTask {
 
     public void setMethodCsv(DelayedFile methodCsv) {
         this.methodCsv = methodCsv;
+    }
+
+    public boolean getCopyEmptyDirectories() {
+        return copyEmptyDirectories;
+    }
+
+    public void setCopyEmptyDirectories(boolean copyEmptyDirectories) {
+        this.copyEmptyDirectories = copyEmptyDirectories;
     }
 
     @Internal

--- a/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
+++ b/src/main/java/net/minecraftforge/gradle/tasks/user/reobf/ReobfTask.java
@@ -294,7 +294,7 @@ public class ReobfTask extends DefaultTask {
         }
 
         for (ObfArtifact obf : getObfuscated())
-            obf.generate(exc, srg, extraSrg, getExtraSrgFiles());
+            obf.generate(exc, srg, extraSrg, getExtraSrgFiles(), getCopyEmptyDirectories());
 
         // cleanup
         srg.delete();
@@ -308,7 +308,6 @@ public class ReobfTask extends DefaultTask {
         exc.excConfig = getExceptorCfg();
         exc.fieldCSV = getFieldCsv();
         exc.methodCSV = getMethodCsv();
-        exc.copyEmptyDirectories = getCopyEmptyDirectories();
 
         exc.doFirstThings();
 


### PR DESCRIPTION
Just made `copyEmptyDirectories` optional (also added getter and setter in tasks with it).

I tested it with `reobf` task when use package relocate (like as #151):
```gradle
tasks.getByName("reobf").doFirst {
    setCopyEmptyDirectories(true);
}
```
All tasks that use remapper, but i not tested this with all of it :woozy_face::
- `reobf`
- `deobfBinJar`
- `deobfuscateJar`


